### PR TITLE
feat: persist devices to LittleFS flash storage

### DIFF
--- a/helpers/DeviceStorage.cpp
+++ b/helpers/DeviceStorage.cpp
@@ -1,0 +1,349 @@
+#include "DeviceStorage.hpp"
+
+#include "esp_littlefs.h"
+#include "cJSON.h"
+#include "esp_log.h"
+
+#include <cstring>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <format>
+
+static const char *TAG = "devStorage";
+
+static constexpr const char *STORAGE_BASE_PATH = "/devices";
+static constexpr const char *STORAGE_PARTITION = "devices";
+
+namespace Helpers
+{
+    esp_err_t DeviceStorage::Init()
+    {
+        esp_vfs_littlefs_conf_t conf = {};
+        conf.base_path = STORAGE_BASE_PATH;
+        conf.partition_label = STORAGE_PARTITION;
+        conf.format_if_mount_failed = true;
+        conf.dont_mount = false;
+
+        esp_err_t err = esp_vfs_littlefs_register(&conf);
+        if (err != ESP_OK)
+        {
+            ESP_LOGE(TAG, "Failed to mount LittleFS partition '%s' (%s)", STORAGE_PARTITION, esp_err_to_name(err));
+            return err;
+        }
+
+        size_t total = 0, used = 0;
+        err = esp_littlefs_info(STORAGE_PARTITION, &total, &used);
+        if (err == ESP_OK)
+        {
+            ESP_LOGI(TAG, "LittleFS partition '%s' mounted: total=%u, used=%u", STORAGE_PARTITION, total, used);
+        }
+
+        return ESP_OK;
+    }
+
+    std::string DeviceStorage::GetDeviceFilePath(const std::string &deviceID)
+    {
+        return std::format("{}/{}.json", STORAGE_BASE_PATH, deviceID);
+    }
+
+    esp_err_t DeviceStorage::WriteDeviceFile(const std::string &filePath, const std::string &deviceID, const StoredDevice &storedDevice)
+    {
+        cJSON *root = cJSON_CreateObject();
+        if (root == nullptr)
+        {
+            ESP_LOGE(TAG, "Failed to create JSON object for %s", deviceID.c_str());
+            return ESP_ERR_NO_MEM;
+        }
+
+        const iohome::IoDevice &dev = storedDevice.device;
+
+        // Device ID (for reference, same as filename)
+        cJSON_AddStringToObject(root, "id", deviceID.c_str());
+
+        // Device name
+        cJSON_AddStringToObject(root, "name", dev.info.name);
+
+        // Node ID as hex string (redundant with filename, but useful for integrity)
+        std::string nodeIdHex;
+        for (int i = 0; i < iohome::NODE_ID_SIZE; i++)
+            nodeIdHex += std::format("{:02X}", dev.info.node_id[i]);
+        cJSON_AddStringToObject(root, "node_id", nodeIdHex.c_str());
+
+        // Device type and subtype
+        cJSON_AddNumberToObject(root, "device_type", static_cast<uint8_t>(dev.info.device_type));
+        cJSON_AddNumberToObject(root, "device_subtype", dev.info.device_subtype);
+
+        // Manufacturer
+        cJSON_AddNumberToObject(root, "manufacturer", static_cast<uint8_t>(dev.info.manufacturer));
+
+        // Info strings
+        cJSON_AddStringToObject(root, "info1", dev.info.info1);
+        cJSON_AddStringToObject(root, "info2", dev.info.info2);
+
+        // Linked remotes
+        cJSON *remotes = cJSON_AddArrayToObject(root, "remotes");
+        if (remotes != nullptr)
+        {
+            for (const std::string &remoteID : storedDevice.linked_remotes)
+            {
+                cJSON_AddItemToArray(remotes, cJSON_CreateString(remoteID.c_str()));
+            }
+        }
+
+        // Write to file
+        const char *jsonStr = cJSON_Print(root);
+        esp_err_t err = ESP_OK;
+        if (jsonStr == nullptr)
+        {
+            ESP_LOGE(TAG, "Failed to serialize JSON for %s", deviceID.c_str());
+            err = ESP_ERR_NO_MEM;
+        }
+        else
+        {
+            FILE *f = fopen(filePath.c_str(), "w");
+            if (f == nullptr)
+            {
+                ESP_LOGE(TAG, "Failed to open file for writing: %s", filePath.c_str());
+                err = ESP_FAIL;
+            }
+            else
+            {
+                fprintf(f, "%s", jsonStr);
+                fclose(f);
+                ESP_LOGI(TAG, "Saved device %s", deviceID.c_str());
+            }
+            cJSON_free((void *)jsonStr);
+        }
+
+        cJSON_Delete(root);
+        return err;
+    }
+
+    esp_err_t DeviceStorage::ReadDeviceFile(const std::string &filePath, std::string &deviceID, StoredDevice &storedDevice)
+    {
+        FILE *f = fopen(filePath.c_str(), "r");
+        if (f == nullptr)
+        {
+            ESP_LOGD(TAG, "Device file not found: %s", filePath.c_str());
+            return ESP_ERR_NOT_FOUND;
+        }
+
+        // Get file size
+        fseek(f, 0, SEEK_END);
+        long fileSize = ftell(f);
+        fseek(f, 0, SEEK_SET);
+
+        if (fileSize <= 0 || fileSize > 4096) // sanity check
+        {
+            ESP_LOGE(TAG, "Invalid file size (%ld) for %s", fileSize, filePath.c_str());
+            fclose(f);
+            return ESP_ERR_INVALID_SIZE;
+        }
+
+        char *buf = new char[fileSize + 1];
+        size_t bytesRead = fread(buf, 1, fileSize, f);
+        fclose(f);
+        buf[bytesRead] = '\0';
+
+        cJSON *root = cJSON_Parse(buf);
+        delete[] buf;
+
+        if (root == nullptr)
+        {
+            ESP_LOGE(TAG, "Failed to parse JSON from %s", filePath.c_str());
+            return ESP_ERR_INVALID_ARG;
+        }
+
+        // Parse device ID
+        cJSON *idItem = cJSON_GetObjectItem(root, "id");
+        if (cJSON_IsString(idItem))
+            deviceID = idItem->valuestring;
+
+        iohome::IoDevice &dev = storedDevice.device;
+        memset(&dev, 0, sizeof(iohome::IoDevice));
+
+        // Parse name
+        cJSON *nameItem = cJSON_GetObjectItem(root, "name");
+        if (cJSON_IsString(nameItem))
+            strncpy(dev.info.name, nameItem->valuestring, iohome::CMD_PARAM_NAME_MAXSIZE - 1);
+
+        // Parse node_id
+        cJSON *nodeIdItem = cJSON_GetObjectItem(root, "node_id");
+        if (cJSON_IsString(nodeIdItem))
+        {
+            std::string hex(nodeIdItem->valuestring);
+            for (int i = 0; i < iohome::NODE_ID_SIZE && (i * 2 + 1) < (int)hex.length(); i++)
+                dev.info.node_id[i] = (uint8_t)strtol(hex.substr(i * 2, 2).c_str(), nullptr, 16);
+        }
+
+        // Parse device type and subtype
+        cJSON *typeItem = cJSON_GetObjectItem(root, "device_type");
+        if (cJSON_IsNumber(typeItem))
+            dev.info.device_type = static_cast<iohome::DeviceType>((uint8_t)typeItem->valuedouble);
+
+        cJSON *subtypeItem = cJSON_GetObjectItem(root, "device_subtype");
+        if (cJSON_IsNumber(subtypeItem))
+            dev.info.device_subtype = (uint8_t)subtypeItem->valuedouble;
+
+        // Parse manufacturer
+        cJSON *mfItem = cJSON_GetObjectItem(root, "manufacturer");
+        if (cJSON_IsNumber(mfItem))
+            dev.info.manufacturer = static_cast<iohome::Manufacturer>((uint8_t)mfItem->valuedouble);
+
+        // Parse info strings
+        cJSON *info1Item = cJSON_GetObjectItem(root, "info1");
+        if (cJSON_IsString(info1Item))
+            strncpy(dev.info.info1, info1Item->valuestring, iohome::CMD_PARAM_INFO1_MAXSIZE - 1);
+
+        cJSON *info2Item = cJSON_GetObjectItem(root, "info2");
+        if (cJSON_IsString(info2Item))
+            strncpy(dev.info.info2, info2Item->valuestring, iohome::CMD_PARAM_INFO2_MAXSIZE - 1);
+
+        // Initialize runtime fields
+        dev.is_stopped = true;
+        dev.is_deleted = false;
+        dev.position = iohome::UNKNOWN_POSITION;
+        dev.target = iohome::UNKNOWN_POSITION;
+        dev.last_status_timestamp = 0;
+        dev.next_status_update_timestamp = 0;
+
+        // Parse linked remotes
+        storedDevice.linked_remotes.clear();
+        cJSON *remotesArray = cJSON_GetObjectItem(root, "remotes");
+        if (cJSON_IsArray(remotesArray))
+        {
+            cJSON *remoteItem = nullptr;
+            cJSON_ArrayForEach(remoteItem, remotesArray)
+            {
+                if (cJSON_IsString(remoteItem))
+                    storedDevice.linked_remotes.push_back(remoteItem->valuestring);
+            }
+        }
+
+        cJSON_Delete(root);
+        return ESP_OK;
+    }
+
+    esp_err_t DeviceStorage::LoadDevice(const std::string &deviceID, StoredDevice &storedDevice)
+    {
+        std::string filePath = GetDeviceFilePath(deviceID);
+        std::string readDeviceID;
+        return ReadDeviceFile(filePath, readDeviceID, storedDevice);
+    }
+
+    esp_err_t DeviceStorage::LoadAll(std::map<std::string, StoredDevice> &devices)
+    {
+        devices.clear();
+
+        DIR *dir = opendir(STORAGE_BASE_PATH);
+        if (dir == nullptr)
+        {
+            ESP_LOGW(TAG, "No device storage directory found, starting fresh");
+            return ESP_OK;
+        }
+
+        struct dirent *entry;
+        while ((entry = readdir(dir)) != nullptr)
+        {
+            std::string filename(entry->d_name);
+            // Only process .json files
+            if (filename.length() < 6 || filename.substr(filename.length() - 5) != ".json")
+                continue;
+
+            std::string filePath = std::format("{}/{}", STORAGE_BASE_PATH, filename);
+            std::string deviceID;
+            StoredDevice storedDevice;
+
+            esp_err_t err = ReadDeviceFile(filePath, deviceID, storedDevice);
+            if (err == ESP_OK && !deviceID.empty())
+            {
+                devices.insert({deviceID, storedDevice});
+                ESP_LOGI(TAG, "Loaded device %s (%s)", deviceID.c_str(), storedDevice.device.info.name);
+            }
+            else
+            {
+                ESP_LOGW(TAG, "Skipping invalid device file: %s", filename.c_str());
+            }
+        }
+
+        closedir(dir);
+        ESP_LOGI(TAG, "Loaded %u device(s) from storage", devices.size());
+        return ESP_OK;
+    }
+
+    esp_err_t DeviceStorage::SaveDevice(const std::string &deviceID, const StoredDevice &device)
+    {
+        std::string filePath = GetDeviceFilePath(deviceID);
+        return WriteDeviceFile(filePath, deviceID, device);
+    }
+
+    esp_err_t DeviceStorage::RemoveDevice(const std::string &deviceID)
+    {
+        std::string filePath = GetDeviceFilePath(deviceID);
+        if (remove(filePath.c_str()) != 0)
+        {
+            ESP_LOGW(TAG, "Could not remove device file %s (may not exist)", deviceID.c_str());
+            return ESP_ERR_NOT_FOUND;
+        }
+        ESP_LOGI(TAG, "Removed device %s from storage", deviceID.c_str());
+        return ESP_OK;
+    }
+
+    esp_err_t DeviceStorage::AddRemoteToDevice(const std::string &remoteID, const std::string &deviceID)
+    {
+        std::string filePath = GetDeviceFilePath(deviceID);
+        std::string readDeviceID;
+        StoredDevice storedDevice;
+
+        esp_err_t err = ReadDeviceFile(filePath, readDeviceID, storedDevice);
+        if (err != ESP_OK)
+        {
+            ESP_LOGE(TAG, "Cannot add remote %s: device %s not found in storage", remoteID.c_str(), deviceID.c_str());
+            return err;
+        }
+
+        // Check if remote already linked
+        for (const std::string &existing : storedDevice.linked_remotes)
+        {
+            if (existing == remoteID)
+                return ESP_OK; // already linked
+        }
+
+        storedDevice.linked_remotes.push_back(remoteID);
+        return WriteDeviceFile(filePath, deviceID, storedDevice);
+    }
+
+    esp_err_t DeviceStorage::RemoveRemote(const std::string &remoteID)
+    {
+        // Iterate over all device files and remove this remote from each
+        DIR *dir = opendir(STORAGE_BASE_PATH);
+        if (dir == nullptr)
+            return ESP_OK;
+
+        struct dirent *entry;
+        while ((entry = readdir(dir)) != nullptr)
+        {
+            std::string filename(entry->d_name);
+            if (filename.length() < 6 || filename.substr(filename.length() - 5) != ".json")
+                continue;
+
+            std::string filePath = std::format("{}/{}", STORAGE_BASE_PATH, filename);
+            std::string deviceID;
+            StoredDevice storedDevice;
+
+            if (ReadDeviceFile(filePath, deviceID, storedDevice) == ESP_OK)
+            {
+                auto it = std::find(storedDevice.linked_remotes.begin(), storedDevice.linked_remotes.end(), remoteID);
+                if (it != storedDevice.linked_remotes.end())
+                {
+                    storedDevice.linked_remotes.erase(it);
+                    WriteDeviceFile(filePath, deviceID, storedDevice);
+                    ESP_LOGI(TAG, "Removed remote %s from device %s", remoteID.c_str(), deviceID.c_str());
+                }
+            }
+        }
+
+        closedir(dir);
+        return ESP_OK;
+    }
+}

--- a/helpers/DeviceStorage.hpp
+++ b/helpers/DeviceStorage.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <string>
+#include <map>
+#include <list>
+
+#include "esp_err.h"
+#include "iohome_device.hpp"
+
+namespace Helpers
+{
+    /// @brief Stored device data (static information + linked remotes)
+    struct StoredDevice
+    {
+        iohome::IoDevice device;                // Device information
+        std::list<std::string> linked_remotes;  // Remote IDs linked to this device
+    };
+
+    class DeviceStorage
+    {
+    public:
+        /// @brief Initialize LittleFS partition for device storage. Must be called before any read/write operation.
+        /// @return ESP_OK if no error
+        static esp_err_t Init();
+
+        /// @brief Load a single device from flash storage
+        /// @param deviceID Device ID (6 characters as hex representation of the 3 bytes, eg "112233")
+        /// @param storedDevice Will be filled with device data
+        /// @return ESP_OK if no error, ESP_ERR_NOT_FOUND if device doesn't exist
+        static esp_err_t LoadDevice(const std::string &deviceID, StoredDevice &storedDevice);
+
+        /// @brief Load all devices from flash storage
+        /// @param devices Map that will be filled with all stored devices (deviceID -> StoredDevice)
+        /// @return ESP_OK if no error
+        static esp_err_t LoadAll(std::map<std::string, StoredDevice> &devices);
+
+        /// @brief Save a device to flash storage (creates or overwrites)
+        /// @param deviceID Device ID (6 characters as hex representation of the 3 bytes, eg "112233")
+        /// @param device Device data to store
+        /// @return ESP_OK if no error
+        static esp_err_t SaveDevice(const std::string &deviceID, const StoredDevice &device);
+
+        /// @brief Remove a device file from flash storage
+        /// @param deviceID Device ID (6 characters as hex representation of the 3 bytes, eg "112233")
+        /// @return ESP_OK if no error, ESP_ERR_NOT_FOUND if device doesn't exist
+        static esp_err_t RemoveDevice(const std::string &deviceID);
+
+        /// @brief Add a remote link to an existing stored device
+        /// @param remoteID Remote ID (6 characters hex)
+        /// @param deviceID Device ID (6 characters hex)
+        /// @return ESP_OK if no error
+        static esp_err_t AddRemoteToDevice(const std::string &remoteID, const std::string &deviceID);
+
+        /// @brief Remove a remote link from all stored devices
+        /// @param remoteID Remote ID (6 characters hex)
+        /// @return ESP_OK if no error
+        static esp_err_t RemoveRemote(const std::string &remoteID);
+
+    private:
+        /// @brief Build the file path for a device
+        /// @param deviceID Device ID
+        /// @return Full path to the device file (eg "/devices/112233.json")
+        static std::string GetDeviceFilePath(const std::string &deviceID);
+
+        /// @brief Serialize a StoredDevice to JSON and write to file
+        /// @param filePath Path to file
+        /// @param deviceID Device ID
+        /// @param storedDevice Device data to serialize
+        /// @return ESP_OK if no error
+        static esp_err_t WriteDeviceFile(const std::string &filePath, const std::string &deviceID, const StoredDevice &storedDevice);
+
+        /// @brief Read and deserialize a device from a JSON file
+        /// @param filePath Path to file
+        /// @param deviceID Will be set to the device ID from the file
+        /// @param storedDevice Will be filled with deserialized device data
+        /// @return ESP_OK if no error
+        static esp_err_t ReadDeviceFile(const std::string &filePath, std::string &deviceID, StoredDevice &storedDevice);
+    };
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,7 +1,8 @@
 idf_component_register(SRCS "cmd_line_management.cpp" "main.cpp" "../io-homecontrol/IoHomeControl.cpp" "../io-homecontrol/protocol/iohome_commands.cpp"
                         "../io-homecontrol/protocol/iohome_crypto.cpp" "../io-homecontrol/protocol/iohome_frame.cpp"
                         "../io-homecontrol/radio/RadioSX1276.cpp" "../helpers/NvsHelpers.cpp" "../helpers/NetworkHelpers.cpp" "../helpers/MqttHelpers.cpp"
+                        "../helpers/DeviceStorage.cpp"
                         "../config/NetworkConfig.cpp" "../config/HardwareConfig.cpp" "../config/MqttConfig.cpp"
                         "IoRtsManager.cpp"
                     INCLUDE_DIRS "." "../helpers" "../io-homecontrol" "../io-homecontrol/protocol" "../io-homecontrol/radio" "../config"
-                    REQUIRES esp_timer esp_driver_spi esp_driver_gpio console esp_driver_uart mbedtls nvs_flash esp_wifi esp_eth mqtt esp_app_format)
+                    REQUIRES esp_timer esp_driver_spi esp_driver_gpio console esp_driver_uart mbedtls nvs_flash esp_wifi esp_eth mqtt esp_app_format littlefs)

--- a/main/IoRtsManager.cpp
+++ b/main/IoRtsManager.cpp
@@ -1,6 +1,7 @@
 #include "IoRtsManager.hpp"
 #include "HardwareConfig.hpp"
 #include "MqttConfig.hpp"
+#include "DeviceStorage.hpp"
 
 #include "esp_log.h"
 #include "sdkconfig.h"
@@ -54,7 +55,9 @@ namespace IoRts
                 // ask for discovery message
                 sendDiscovery = true;
                 // add device to flash storage
-                // TODO
+                Helpers::StoredDevice storedDevice = {};
+                storedDevice.device = device;
+                Helpers::DeviceStorage::SaveDevice(deviceID, storedDevice);
             }
             else
             {
@@ -71,11 +74,30 @@ namespace IoRts
                     sendDiscovery = true;
                     memcpy(it->second.info.name, device.info.name, sizeof(device.info.name)); // could be update by "SetName"
                 }
+                // Update device type/subtype if they were unknown and now available
+                if (it->second.info.device_type == iohome::DeviceType::UNKNOWN && device.info.device_type != iohome::DeviceType::UNKNOWN)
+                {
+                    sendDiscovery = true;
+                    it->second.info.device_type = device.info.device_type;
+                    it->second.info.device_subtype = device.info.device_subtype;
+                    it->second.info.manufacturer = device.info.manufacturer;
+                }
                 it->second.is_stopped = device.is_stopped;
                 it->second.last_status_timestamp = device.last_status_timestamp;
                 it->second.next_status_update_timestamp = device.next_status_update_timestamp;
                 it->second.position = device.position;
                 it->second.target = device.target;
+                // Update storage when static device info changed (name, type, ...)
+                if (sendDiscovery)
+                {
+                    // Load existing file to preserve linked remotes, then update device info
+                    Helpers::StoredDevice storedDevice = {};
+                    storedDevice.device = it->second;
+                    Helpers::StoredDevice existing;
+                    if (Helpers::DeviceStorage::LoadDevice(deviceID, existing) == ESP_OK)
+                        storedDevice.linked_remotes = existing.linked_remotes;
+                    Helpers::DeviceStorage::SaveDevice(deviceID, storedDevice);
+                }
             }
             sIoRtsManager->mIoDevicesMutex.unlock(); // release mutex as MQTT needs it!
             // send MQTT messages
@@ -94,8 +116,12 @@ namespace IoRts
     IoRtsManager::IoRtsManager()
     {
         sIoRtsManager = this;
+        // Initialize device storage (mount LittleFS)
+        InitializeStorage();
         // Initialize IO objects
         InitializeIo();
+        // Load devices from flash storage
+        LoadDevicesFromStorage();
         // Initialize MQTT objects
         InitializeMqtt();
         // Start everything
@@ -131,8 +157,8 @@ namespace IoRts
             // Update mIODevices
             it->second.is_deleted = true;
             // Remove from storage
-            // TODO
-            sIoRtsManager->mIoDevicesMutex.unlock(); // release mutex as MQTT needs it!
+            Helpers::DeviceStorage::RemoveDevice(deviceID);
+            sIoRtsManager->mIoDevicesMutex.unlock(); // release mutex as MQTT needs it!;
             if (sMqttHelper != nullptr)
             {
                 // send MQTT discovery message
@@ -153,7 +179,7 @@ namespace IoRts
         if (success)
         {
             // Add remote to storage
-            // TODO
+            Helpers::DeviceStorage::AddRemoteToDevice(remoteID, deviceID);
         }
         return success;
     }
@@ -163,7 +189,47 @@ namespace IoRts
         if (mIoHome != nullptr)
             mIoHome->DeleteRemote(remoteID);
         // Remove from storage
-        // TODO
+        Helpers::DeviceStorage::RemoveRemote(remoteID);
+    }
+    void IoRtsManager::InitializeStorage()
+    {
+        esp_err_t err = Helpers::DeviceStorage::Init();
+        if (err != ESP_OK)
+        {
+            ESP_LOGE(TAG, "Failed to initialize device storage (%s)", esp_err_to_name(err));
+        }
+    }
+    void IoRtsManager::LoadDevicesFromStorage()
+    {
+#ifdef CONFIG_ENABLE_IOHOMECONTROL
+        if (mIoHome == nullptr)
+            return;
+
+        std::map<std::string, Helpers::StoredDevice> storedDevices;
+        esp_err_t err = Helpers::DeviceStorage::LoadAll(storedDevices);
+        if (err != ESP_OK)
+        {
+            ESP_LOGE(TAG, "Failed to load devices from storage (%s)", esp_err_to_name(err));
+            return;
+        }
+
+        for (const auto &[deviceID, storedDevice] : storedDevices)
+        {
+            // Register device in protocol layer
+            mIoHome->AddDevice(deviceID);
+            // Add to our local map
+            mIoDevicesMutex.lock();
+            mIoDevices.insert({deviceID, storedDevice.device});
+            mIoDevicesMutex.unlock();
+            // Restore remote links
+            for (const std::string &remoteID : storedDevice.linked_remotes)
+            {
+                mIoHome->LinkRemoteToDevice(remoteID, deviceID);
+            }
+            ESP_LOGI(TAG, "Restored device %s (%s) with %u remote(s)",
+                     deviceID.c_str(), storedDevice.device.info.name, storedDevice.linked_remotes.size());
+        }
+#endif // ENABLE_IOHOMECONTROL
     }
     void IoRtsManager::InitializeIo()
     {

--- a/main/IoRtsManager.hpp
+++ b/main/IoRtsManager.hpp
@@ -3,6 +3,7 @@
 #include "MqttHelpers.hpp"
 #include "RadioSX1276.hpp"
 #include "IoHomeControl.hpp"
+#include "DeviceStorage.hpp"
 
 #include <map>
 #include <mutex>
@@ -44,6 +45,12 @@ namespace IoRts
 
     private:
         bool mIoPassive = false; // current configuration, initialized at boot
+
+        /// @brief Initialize device storage (mount LittleFS partition)
+        void InitializeStorage();
+
+        /// @brief Load devices and remotes from flash storage, register them in IoHomeControl
+        void LoadDevicesFromStorage();
 
         /// @brief Initialize Io objects members (mSX1276Radio, mIoHome)
         void InitializeIo();

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -20,3 +20,4 @@ dependencies:
     - if: $CONFIG{CONNECTIVITY_CHOICE_ETH} == True
   espressif/mqtt: ^1.0.0
   espressif/cjson: ^1.7.19~2
+  joltwallet/littlefs: ^1.20.4


### PR DESCRIPTION
## Summary
- Persist devices and linked remotes to the `devices` LittleFS partition as JSON files
- Devices are restored on boot, surviving reboots and re-flashing
- Replaces all TODO placeholders in IoRtsManager

Implemented with AI assistance (OpenCode / Claude).