### PR TITLE
Fix Latin-1 device names and challenge response timeout

### DIFF
--- a/helpers/EncodingHelpers.cpp
+++ b/helpers/EncodingHelpers.cpp
@@ -1,0 +1,60 @@
+#include "EncodingHelpers.hpp"
+
+namespace Helpers
+{
+    std::string EncodingHelpers::Latin1ToUtf8(const uint8_t *data, size_t len)
+    {
+        std::string result;
+        result.reserve(len * 2); // worst case: every byte becomes 2 UTF-8 bytes
+        for (size_t i = 0; i < len; i++)
+        {
+            uint8_t ch = data[i];
+            if (ch == 0) // null terminator in source data
+                break;
+            if (ch < 0x80)
+                result += static_cast<char>(ch);
+            else
+            {
+                result += static_cast<char>(0xC0 | (ch >> 6));
+                result += static_cast<char>(0x80 | (ch & 0x3F));
+            }
+        }
+        return result;
+    }
+
+    std::string EncodingHelpers::Utf8ToLatin1(const std::string &utf8)
+    {
+        std::string result;
+        result.reserve(utf8.size());
+        for (size_t i = 0; i < utf8.size(); i++)
+        {
+            uint8_t ch = static_cast<uint8_t>(utf8[i]);
+            if (ch < 0x80)
+            {
+                result += static_cast<char>(ch);
+            }
+            else if ((ch & 0xE0) == 0xC0 && i + 1 < utf8.size())
+            {
+                // 2-byte UTF-8 sequence: 110xxxxx 10xxxxxx
+                uint16_t codepoint = ((ch & 0x1F) << 6) | (static_cast<uint8_t>(utf8[i + 1]) & 0x3F);
+                if (codepoint <= 0xFF)
+                    result += static_cast<char>(codepoint);
+                else
+                    result += '?'; // outside Latin-1 range
+                i++; // skip continuation byte
+            }
+            else if ((ch & 0xF0) == 0xE0)
+            {
+                result += '?'; // 3-byte UTF-8, outside Latin-1
+                i += 2;
+            }
+            else if ((ch & 0xF8) == 0xF0)
+            {
+                result += '?'; // 4-byte UTF-8, outside Latin-1
+                i += 3;
+            }
+            // else: stray continuation byte, skip
+        }
+        return result;
+    }
+}

--- a/helpers/EncodingHelpers.hpp
+++ b/helpers/EncodingHelpers.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stdint.h>
+#include <string>
+
+namespace Helpers
+{
+    class EncodingHelpers
+    {
+    public:
+        /// @brief Convert Latin-1 (ISO-8859-1) encoded bytes to a UTF-8 std::string.
+        /// IO-Homecontrol devices transmit names in Latin-1 encoding.
+        /// @param data Pointer to Latin-1 encoded bytes
+        /// @param len Number of bytes to convert
+        /// @return UTF-8 encoded std::string
+        static std::string Latin1ToUtf8(const uint8_t *data, size_t len);
+
+        /// @brief Convert a UTF-8 std::string to Latin-1 bytes for sending to a device.
+        /// Characters outside Latin-1 range (U+0100+) are replaced with '?'.
+        /// @param utf8 UTF-8 encoded string
+        /// @return Latin-1 encoded std::string
+        static std::string Utf8ToLatin1(const std::string &utf8);
+    };
+}

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -6,6 +6,7 @@
 
 #include "IoHomeControl.hpp"
 #include "iohome_commands.hpp"
+#include "EncodingHelpers.hpp"
 #include "esp_task_wdt.h"
 #include "esp_timer.h"
 #include "freertos/task.h"
@@ -916,13 +917,16 @@ namespace iohome
       bool ret = false;
       UBaseType_t currentPriority = uxTaskPriorityGet(NULL);
       vTaskPrioritySet(NULL, IO_FRAME_PROCESSING_TASK); // change task priority to higher!
-      if (create_setname_request(request, mOwnNodeId, it->second.info.node_id, name.c_str(), name.length() + 1) && SendAndReceive(request, response, FREQUENCY_CHANNEL_2))
+      // Convert UTF-8 name to Latin-1 for the device (IO-Homecontrol uses Latin-1)
+      std::string latin1Name = Helpers::EncodingHelpers::Utf8ToLatin1(name);
+      if (create_setname_request(request, mOwnNodeId, it->second.info.node_id, latin1Name.c_str(), latin1Name.length() + 1) && SendAndReceive(request, response, FREQUENCY_CHANNEL_2))
       {
         if (response.command_id == CMD_SET_NAME_ANSWER)
         {
-          // Update Device Status
+          // Update Device Status — store the UTF-8 version in memory
           memset(it->second.info.name, 0, sizeof(it->second.info.name));
-          memcpy(it->second.info.name, name.c_str(), name.length());
+          size_t copyLen = name.length() < CMD_PARAM_NAME_MAXSIZE - 1 ? name.length() : CMD_PARAM_NAME_MAXSIZE - 1;
+          memcpy(it->second.info.name, name.c_str(), copyLen);
           if (!xQueueSendToBack(sIoDeviceStatusQueue, &it->second, 0))
           {
             IO_LOGE("UpdateDeviceStatus can't add device to queue!");
@@ -1216,7 +1220,16 @@ namespace iohome
         // statusFrame.data[0]: don't know why, on some devices it is 0x00, on others it is first character (eg DexxoSmartio800)
         // last char in data field is 0x00 or 0x20, don't copy it, so copy at most (len - 2) bytes
         uint8_t begin = statusFrame.data[0] > 0x20 ? 0 : 1;
-        std::string name = std::string(statusFrame.data + begin, statusFrame.data + statusFrame.data_len - begin).substr(0, CMD_PARAM_NAME_MAXSIZE - 1);
+        size_t rawLen = statusFrame.data_len - begin;
+        // Strip trailing null/space bytes
+        while (rawLen > 0 && (statusFrame.data[begin + rawLen - 1] == 0x00 || statusFrame.data[begin + rawLen - 1] == 0x20))
+          rawLen--;
+        // Convert Latin-1 (IO-Homecontrol encoding) to UTF-8
+        std::string name = Helpers::EncodingHelpers::Latin1ToUtf8(statusFrame.data + begin, rawLen);
+        // Truncate to fit buffer (leave room for null terminator)
+        if (name.length() >= CMD_PARAM_NAME_MAXSIZE)
+          name.resize(CMD_PARAM_NAME_MAXSIZE - 1);
+        memset(deviceIt->second.info.name, 0, sizeof(deviceIt->second.info.name));
         memcpy(deviceIt->second.info.name, name.c_str(), name.length());
       }
       // Note: don't notify device update here, as it is a frame received during device add (notification will be sent later)

--- a/io-homecontrol/protocol/iohome_commands.cpp
+++ b/io-homecontrol/protocol/iohome_commands.cpp
@@ -249,8 +249,9 @@ namespace iohome
         const IoFrame &origin_frame,
         const uint8_t *key)
     {
-        // Initialize frame for 2W mode
-        init_frame(outframe);
+        // Initialize frame for 2W mode, with START flag so the radio task
+        // waits 300ms (instead of 50ms) for the device's final response
+        init_frame(outframe, true, true);
 
         // Set source and destination
         set_destination(outframe, dest_node);

--- a/io-homecontrol/protocol/iohome_constants.h
+++ b/io-homecontrol/protocol/iohome_constants.h
@@ -148,7 +148,7 @@ namespace iohome
   constexpr uint8_t CMD_PARAM_POSITION_UNKNOWN = 0xD4;  // UNKNOWN POSITION
   constexpr uint8_t CMD_PARAM_POSITION_FAVORITE = 0xD8; // FAVORITE POSITION
 
-  constexpr uint8_t CMD_PARAM_NAME_MAXSIZE = 16;
+  constexpr uint8_t CMD_PARAM_NAME_MAXSIZE = 32; // 32 to accommodate Latin-1 -> UTF-8 expansion (each non-ASCII byte may become 2 bytes)
   constexpr uint8_t CMD_PARAM_INFO1_MAXSIZE = 16;
   constexpr uint8_t CMD_PARAM_INFO2_MAXSIZE = 16;
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,7 +1,7 @@
 idf_component_register(SRCS "cmd_line_management.cpp" "main.cpp" "../io-homecontrol/IoHomeControl.cpp" "../io-homecontrol/protocol/iohome_commands.cpp"
                         "../io-homecontrol/protocol/iohome_crypto.cpp" "../io-homecontrol/protocol/iohome_frame.cpp"
                         "../io-homecontrol/radio/RadioSX1276.cpp" "../helpers/NvsHelpers.cpp" "../helpers/NetworkHelpers.cpp" "../helpers/MqttHelpers.cpp"
-                        "../helpers/DeviceStorage.cpp"
+                        "../helpers/DeviceStorage.cpp" "../helpers/EncodingHelpers.cpp"
                         "../config/NetworkConfig.cpp" "../config/HardwareConfig.cpp" "../config/MqttConfig.cpp"
                         "IoRtsManager.cpp"
                     INCLUDE_DIRS "." "../helpers" "../io-homecontrol" "../io-homecontrol/protocol" "../io-homecontrol/radio" "../config"


### PR DESCRIPTION
## Summary
- Convert Latin-1 encoded device names to UTF-8, fixing special characters (e.g. `Büro`) in MQTT discovery and logs
- Add `EncodingHelpers` class with `Latin1ToUtf8` / `Utf8ToLatin1` for reuse
- Increase `CMD_PARAM_NAME_MAXSIZE` from 16 to 32 for UTF-8 expansion
- Set START flag on `0x3D` challenge response frame so radio waits 300ms instead of 50ms for the device's final response

> **Depends on** https://github.com/nicolas5000/io-rts-esp32/pull/4 — merge that first.

*AI-assisted development (Claude)*