### PR TITLE
Tilt support for venetian blind devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ build/
 *.elf
 *.map
 flasher_args.json # Generated in build directory
-sdkconfig.old
+sdkconfig*.old
 sdkconfig
 
 # ESP-IDF dependencies
@@ -82,3 +82,7 @@ Desktop.ini
 *.workspace # General workspace files, can be from various tools
 *.suo       # Visual Studio Solution User Options
 *.sln.docstates # Visual Studio
+
+# AI
+.opencode
+AGENTS.md

--- a/doc/tilted_cover.md
+++ b/doc/tilted_cover.md
@@ -1,0 +1,314 @@
+# Tilted Cover Commands
+
+- **Controller (sender):** `AA9BFA`
+- **Actuator (receiver):** `EE8165`
+
+---
+
+# Close Tilt (0%)
+
+Captured command sequence for closing the tilt of an already fully-down cover (position 0%) to tilt-closed (tilt 0%).
+
+## Command Sequence
+
+| # | Freq (MHz) | Command | Name | Direction | CTRL0 | CTRL1 | Data (hex) | Notes |
+|---|-----------|---------|------|-----------|-------|-------|------------|-------|
+| 1 | 868.95 | 0x00 | EXECUTE_REQUEST | AA9BFA -> EE8165 | 50 | 00 | 01E7D20020C80000 | Auth required. Payload: position D2=STOP?, 20C80000 (C800 = 100% closed) |
+| 2 | 868.95 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 6EC5276AC060 | Authentication response to challenge (for cmd 0x00) |
+| 3 | 868.25 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION, pos 0000 |
+| 4 | 868.25 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05, C800 = 100% closed, 0000 |
+| 5 | 868.25 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status query/command |
+| 6 | 868.25 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 078809D92735 | Auth response (for cmd 0x03) |
+| 7 | 868.95 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION, pos 0000 (repeat) |
+| 8 | 868.95 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | FDB9BF961F1C | Auth response |
+| 9 | 868.95 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05, C800 = 100% closed |
+| 10 | 869.85 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status query/command (repeat on new freq) |
+| 11 | 869.85 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | FE1B17AD1BB4 | Auth response (for cmd 0x03) |
+| 12 | 869.85 | 0x04 | PRIVATE_RESPONSE | EE8165 -> AA9BFA | 98 | 00 | 0500D200D8000000AA9BFA0120C80000 | Full status: 05=stopped, D2=STOP_POS, D8=FAVORITE, target AA9BFA, pos C800=100% |
+| 13 | 868.25 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION (final) |
+| 14 | 868.25 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05, C800 = 100% closed |
+
+## Observations
+
+- The cover is already at position C800 (100% closed / fully down). This command closes the tilt.
+- Command 0x00 (EXECUTE_REQUEST) initiates the tilt action, followed immediately by a 0x3D challenge response (authentication).
+- Command 0x0C (PRIVATE2) with data `D8000000` (D8 = FAVORITE_POSITION with value 0000) is sent multiple times across different frequencies (frequency hopping: 868.25, 868.95, 869.85 MHz).
+- Command 0x03 (PRIVATE) with data `03200100` appears to be a status request or tilt-specific command, also requiring authentication (followed by 0x3D).
+- Command 0x04 (PRIVATE_RESPONSE) returns full device status including current position, target address, and parameters.
+- All 0x0D responses contain `05C8000000` confirming position C800 (100% closed) with status byte 05 (stopped, bit 0 set).
+- CTRL0 values: 50 (execute), 0E (challenge response), 4C (private commands from controller), 8D (private response from device), 98 (private response with extended data).
+
+---
+
+# Open Tilt (100%)
+
+Captured command sequence for opening the tilt of an already fully-down cover (position C800 = 100% closed) to tilt-open (tilt 100%). Cover remains down, only tilt changes.
+
+## Command Sequence
+
+| # | Freq (MHz) | Command | Name | Direction | CTRL0 | CTRL1 | Data (hex) | Notes |
+|---|-----------|---------|------|-----------|-------|-------|------------|-------|
+| 1 | 869.85 | 0x00 | EXECUTE_REQUEST | AA9BFA -> EE8165 | 50 | 00 | 01E7D20020000000 | Auth required. Target tilt position 0000 = 0% (fully open tilt) |
+| 2 | 869.85 | 0x3C | CHALLENGE_REQUEST | EE8165 -> AA9BFA | 0E | 00 | 573E98267E45 | Device sends challenge |
+| 3 | 869.85 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 61F01456D8F3 | Controller responds to challenge |
+| 4 | 868.95 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION, pos 0000 |
+| 5 | 868.95 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 71B8FDFF734E | Auth response (for cmd 0x0C) |
+| 6 | 868.95 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05=stopped, C800=100% closed |
+| 7 | 868.25 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status/tilt command |
+| 8 | 868.25 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 4B17B2E2C541 | Auth response (for cmd 0x03) |
+| 9 | 869.85 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION (repeat) |
+| 10 | 869.85 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 2D8BC430BEC3 | Auth response |
+| 11 | 869.85 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05=stopped, C800=100% closed |
+| 12 | 868.95 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status/tilt command (repeat) |
+| 13 | 868.95 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | F71F13C22A11 | Auth response (for cmd 0x03) |
+| 14 | 868.95 | 0x04 | PRIVATE_RESPONSE | EE8165 -> AA9BFA | 98 | 00 | 0500D200D8000000AA9BFA0120000000 | Full status: 05=stopped, pos C800, tilt target 0000=0% (open) |
+| 15 | 868.25 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION (final) |
+| 16 | 868.25 | 0x3C | CHALLENGE_REQUEST | EE8165 -> AA9BFA | 0E | 00 | 0D333C6EBA46 | Device sends challenge |
+| 17 | 868.25 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | A5084B984F14 | Controller responds to challenge |
+| 18 | 868.25 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05=stopped, C800=100% closed |
+
+## Observations
+
+- The EXECUTE_REQUEST payload is `01E7D20020000000` — the key difference from close-tilt is the last 4 bytes: `00000000` (tilt open) vs `C8000000` (tilt closed).
+- This capture includes the full 0x3C CHALLENGE_REQUEST from the device (not seen in close-tilt capture, likely missed there).
+- The 0x04 PRIVATE_RESPONSE confirms: `0500D200D8000000AA9BFA0120000000` — last 4 bytes `00000000` = tilt target 0% (fully open), while cover position remains C800 (fully down).
+- Command 0x0C (PRIVATE2) with `D8000000` and 0x03 (PRIVATE) with `03200100` repeat across frequencies, same pattern as close-tilt.
+- The final 0x0C on frame 15 triggers a new 0x3C/0x3D challenge exchange before the 0x0D ACK — suggesting the device may periodically re-authenticate.
+
+---
+
+# Comparison: Close Tilt vs Open Tilt
+
+| Aspect | Close Tilt (0%) | Open Tilt (100%) |
+|--------|----------------|-----------------|
+| EXECUTE_REQUEST data | `01E7D20020C80000` | `01E7D20020000000` |
+| Tilt target value | C800 (100% closed) | 0000 (0% = fully open) |
+| PRIVATE_RESPONSE tail | `...0120C80000` | `...0120000000` |
+| Cover position in responses | C800 (down) | C800 (down) |
+| Overall structure | Identical | Identical |
+
+The tilt position is encoded in the last 4 bytes of the EXECUTE_REQUEST payload (bytes 5-8): `C800` = closed, `0000` = open. The same value appears in the PRIVATE_RESPONSE (0x04) as the tilt target.
+
+---
+
+# Set Position to 80% (No Tilt Change)
+
+Captured command sequence for moving the cover to 80% closed (position only, no tilt parameter). The cover moves from its current position to the target. Log is partial (capture cut short).
+
+## Command Sequence
+
+| # | Freq (MHz) | Command | Name | Direction | CTRL0 | CTRL1 | Data (hex) | Notes |
+|---|-----------|---------|------|-----------|-------|-------|------------|-------|
+| 1 | 868.25 | 0x00 | EXECUTE_REQUEST | AA9BFA -> EE8165 | 4E | 00 | 01E728000000 | Position-only command. Target 2800 = 80% closed (0x28=40 decimal, 40/0.5=80%) |
+| 2 | 868.25 | 0x3C | CHALLENGE_REQUEST | EE8165 -> AA9BFA | 0E | 00 | 004C39746259 | Device sends challenge |
+| 3 | 868.25 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 5FA2688FEF6A | Controller responds to challenge |
+| 4 | 868.25 | 0x04 | PRIVATE_RESPONSE | EE8165 -> AA9BFA | 96 | 00 | 0480280014160006AA9BFA010000 | Status: 04=moving, target 2800=80%, current 1416=~40%?, originator AA9BFA |
+| 5 | 869.85 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status query (log ends here) |
+
+## Observations
+
+- **CTRL0 = 4E** on EXECUTE_REQUEST vs 50 in the tilt commands. This likely indicates a different command subtype (position-only vs position+tilt).
+- **Payload `01E728000000`** is only 6 bytes vs 8 bytes for tilt commands (`01E7D20020xxxx00`). The format differs:
+  - Position-only: `01 E7 28 00 00 00` — byte 2 = `28` (target position 0x2800 = 80%)
+  - Tilt commands: `01 E7 D2 00 20 xx xx 00` — byte 2 = `D2` (STOP_POSITION param), bytes 5-6 = tilt value
+- **0x04 PRIVATE_RESPONSE with CTRL0=96** (vs 98 in tilt commands): 14 bytes vs 16 bytes. Payload `0480280014160006AA9BFA010000`:
+  - `04` = status moving (not stopped, bit 0 clear)
+  - `80` = flags (CMD_PARAM_STATUS_EXPECTED set — device will send STATUS_UPDATE)
+  - `2800` = target position (80% closed)
+  - `1416` = current position (device in motion)
+  - `0006` = unknown (speed? timer?)
+  - `AA9BFA` = originator address
+  - `01` = unknown
+  - `0000` = tilt position (unchanged/not specified)
+- **No 0x0C (PRIVATE2)** commands seen — those only appear in tilt sequences.
+- The capture ends early (only 5 frames captured vs 14-18 for tilt commands).
+
+---
+
+# Comparison: Position vs Tilt Commands
+
+| Aspect | Position Only (80%) | Tilt (open/close) |
+|--------|-------------------|-------------------|
+| EXECUTE_REQUEST CTRL0 | 4E | 50 |
+| EXECUTE_REQUEST size | 6 bytes | 8 bytes |
+| Payload byte 2 | Position value (0x28=80%) | D2 (STOP_POSITION param) |
+| Tilt value in payload | Not present | Bytes 5-6 (0000 or C800) |
+| PRIVATE_RESPONSE CTRL0 | 96 | 98 |
+| PRIVATE_RESPONSE size | 14 bytes | 16 bytes |
+| PRIVATE2 (0x0C) used | No | Yes (repeated with D8000000) |
+| Device status byte | 04 (moving) | 05 (stopped) |
+
+## EXECUTE_REQUEST Payload Format
+
+```
+Position only (CTRL0=4E, 6 bytes):
+  01 E7 PP PP 00 00
+  PP PP = target position (big-endian, 0x0000=0%/open, 0xC800=100%/closed)
+
+Position + Tilt (CTRL0=50, 8 bytes):
+  01 E7 D2 00 20 TT TT 00
+  D2 = STOP_POSITION parameter marker
+  20 = separator/flag
+  TT TT = tilt value (0x0000=open, 0xC800=closed)
+```
+
+---
+
+# Tilt to 25% at Position 80%
+
+Captured command sequence for setting tilt to 25% while the cover is at 80% closed. Partial capture.
+
+## Command Sequence
+
+| # | Freq (MHz) | Command | Name | Direction | CTRL0 | CTRL1 | Data (hex) | Notes |
+|---|-----------|---------|------|-----------|-------|-------|------------|-------|
+| 1 | 868.95 | 0x00 | EXECUTE_REQUEST | AA9BFA -> EE8165 | 50 | 00 | 01E7D20020960000 | Tilt command. Target tilt 9600 = 75% closed (25% open) |
+| 2 | 868.95 | 0x04 | PRIVATE_RESPONSE | EE8165 -> AA9BFA | 96 | 00 | 0480D20027F90001AA9BFA010000 | Moving: target D200=?, current 27F9, originator AA9BFA |
+| 3 | 869.85 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status query |
+| 4 | 869.85 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | B936EE2A3074 | Auth response (for cmd 0x03) |
+
+## Observations
+
+- **Tilt value `9600`**: In the EXECUTE_REQUEST `01E7D20020960000`, bytes 5-6 = `9600`. Since C800 = 100% closed and 0000 = 0% (fully open), then 9600 = 0x9600/0xC800 = 75% closed = **25% open tilt**. This confirms tilt is expressed as "closed percentage" (inverted from user-facing "open" percentage).
+- **CTRL0 = 96 on 0x04 response** (14 bytes, not 16) — same as the position-only response format, not the 98/16-byte tilt format seen when cover is stationary. The device appears to be moving (status `04`, bit 0 clear).
+- **Response payload `0480D20027F90001AA9BFA010000`**:
+  - `04` = moving
+  - `80` = STATUS_EXPECTED flag
+  - `D200` = D2 parameter (STOP_POSITION) — matches the command
+  - `27F9` = current position in transit (~79.8% — close to the 80% target from previous move)
+  - `0001` = unknown
+  - `AA9BFA` = originator
+  - `01` = unknown
+  - `0000` = tilt (current or previous — not yet at target)
+- The 0x3C challenge was likely sent but not captured (or auth was cached from previous exchange). Only 0x3D response seen.
+- Capture ends early — likely more 0x0C/0x0D exchanges would follow.
+
+## Tilt Value Mapping
+
+| User-facing tilt | Hex value | Calculation |
+|-----------------|-----------|-------------|
+| 0% (closed) | C800 | 100% of C800 |
+| 25% (open) | 9600 | 75% of C800 |
+| 50% | 6400 | 50% of C800 |
+| 75% | 3200 | 25% of C800 |
+| 100% (fully open) | 0000 | 0% of C800 |
+
+Tilt is encoded as **closed percentage**: `tilt_hex = (100 - open_percent) * 0xC800 / 100`
+
+---
+
+# Tilt 25% at Position 80% — io_add Response
+
+Output from `io_add EE8165` (device already paired, requesting status via 0x03 PRIVATE):
+
+## Command Sequence
+
+| # | Freq (MHz) | Command | Name | Direction | CTRL0 | CTRL1 | Data (hex) | Notes |
+|---|-----------|---------|------|-----------|-------|-------|------------|-------|
+| 1 | 868.95 | 0x03 | PRIVATE | 696969 -> EE8165 | 4B | 20 | 030000 | Status request from our controller |
+| 2 | 868.95 | 0x3C | CHALLENGE_REQUEST | EE8165 -> 696969 | 0E | 00 | DED10FD04E80 | Device challenge |
+| 3 | 868.95 | 0x3D | CHALLENGE_RESPONSE | 696969 -> EE8165 | 0E | 00 | FD79458949A6 | Controller auth response |
+| 4 | 868.95 | 0x04 | PRIVATE_RESPONSE | EE8165 -> 696969 | 96 | 00 | 05002800280A0000696969010000 | Stopped, pos 2800=80%, target 2800=80% |
+
+## Observations
+
+- Device type `0x11` = EXTERNAL_VENETIAN_BLIND, subtype `0x00`.
+- The 0x04 response is **14 bytes with CTRL0=96** — same format as position-only movement response.
+- **Response payload `05002800280A0000696969010000`**:
+  - `05` = stopped (bit 0 set)
+  - `00` = flags (no STATUS_EXPECTED)
+  - `2800` = target position (80% closed, matches `0x28 * 2 = 0x50 = 80`)
+  - `280A` = current position (should be 2800 but shows 280A — minor deviation or includes sub-position?)
+  - `0000` = timer/speed (zero, not moving)
+  - `696969` = originator (our controller address)
+  - `01` = unknown
+  - `0000` = **tilt value = 0000 = fully open (100% tilt open)**
+
+Wait — this contradicts! The test scenario says "tilt 25%" but the response shows `0000` (fully open tilt). Let me re-examine...
+
+Actually looking more carefully at the parsed position: bytes 2-3 = `2800` (target), bytes 4-5 = `280A`. If we follow the format from the tilt commands where the 14-byte response is:
+```
+[0]  status    = 05 (stopped)
+[1]  flags     = 00
+[2-3] target   = 2800 (position 80%)
+[4-5] current  = 280A (≈80%)
+[6-7] ????     = 0000
+[8-10] origin  = 696969
+[11] unknown   = 01
+[12-13] tilt   = 0000
+```
+
+The last 2 bytes `0000` would indicate tilt is fully open — **but this is the `io_add` status query using the basic `030000` request**. To get tilt info, send `03200100` instead.
+
+---
+
+# PRIVATE_RESPONSE Formats (Corrected)
+
+## 14-byte response (CTRL0=96)
+
+Returned immediately after an EXECUTE_REQUEST (position or tilt command), or from a basic `030000` status query.
+
+```
+Byte  Field                Example (position cmd)   Example (tilt cmd)
+[0]   status               04 (moving)              04 (moving)
+[1]   flags                80 (STATUS_EXPECTED)     80
+[2-3] target/marker        2800 (pos target 80%)    D200 (D2 = tilt marker)
+[4-5] current position     1416 (~40%)              27F9 (~80%)
+[6-7] timer/unknown        0006                     0001
+[8-10] originator          AA9BFA                   AA9BFA
+[11]  unknown              01                       01
+[12-13] tilt/zero          0000                     0000
+```
+
+- When `byte[2] == D2`: This is a tilt operation response. Bytes 2-3 are NOT a position target.
+  Current position is in bytes [4-5]. No tilt value is reported here.
+- When `byte[2] != D2`: Standard position response. Bytes [2-3] = target position, [4-5] = current position.
+
+## 16-byte response (CTRL0=98)
+
+Returned in response to a `03200100` status query on tilt-capable devices.
+
+```
+Byte  Field                Example: close-tilt      Example: open-tilt
+[0]   status               05 (stopped)             05 (stopped)
+[1]   flags                00                       00
+[2]   D2 marker            D2                       D2
+[3]   zero                 00                       00
+[4-5] current position     D800 (*)                 D800 (*)
+[6-7] unknown              0000                     0000
+[8-10] originator          AA9BFA                   AA9BFA
+[11]  separator            01                       01
+[12]  tilt flag            20                       20
+[13-14] tilt (closed %)    C800 (100% closed)       0000 (0% closed = open)
+[15]  zero                 00                       00
+```
+
+(*) Note: In the Tahoma captures above, bytes [4-5] show `D800` which is the FAVORITE_POSITION
+marker from preceding PRIVATE2 exchanges. In practice with our controller (no PRIVATE2), bytes
+[4-5] contain the actual current position value (confirmed via testing: values like 2800=80% etc).
+
+**Tilt decoding**: `tilt_open_percent = 100 - (bytes[13-14] * 100 / 0xC800)`
+
+---
+
+# Detecting Tilt Support
+
+Based on the captured data, tilt support can be determined by:
+
+1. **Device type** (from INFO2 response during discovery/add):
+   - `VENETIAN_BLIND (0x01)` — tilt supported
+   - `BLIND (0x0A)` — tilt likely supported
+   - `EXTERNAL_VENETIAN_BLIND (0x11)` — tilt supported (confirmed by this device)
+   - `LOUVRE_BLIND (0x12)` — tilt likely supported
+
+2. **CTRL0 in EXECUTE_REQUEST**:
+   - `4E` = position-only command (6 bytes payload)
+   - `50` = position+tilt command (8 bytes payload)
+
+3. **CTRL0 in PRIVATE_RESPONSE (0x04)**:
+   - `96` = 14-byte response (position info, basic)
+   - `98` = 16-byte response (includes explicit tilt value in extended format)
+
+4. **Status query format**:
+   - `030000` (3 bytes) = basic query, returns 14-byte response without tilt
+   - `03200100` (4 bytes) = tilt-aware query, returns 16-byte response with tilt value

--- a/doc/tilted_cover.md
+++ b/doc/tilted_cover.md
@@ -1,314 +1,104 @@
-# Tilted Cover Commands
+# IO-Homecontrol Tilt Protocol
 
-- **Controller (sender):** `AA9BFA`
-- **Actuator (receiver):** `EE8165`
+## Tilt-Capable Device Types
 
----
+From INFO2 response (`device_type` field):
 
-# Close Tilt (0%)
-
-Captured command sequence for closing the tilt of an already fully-down cover (position 0%) to tilt-closed (tilt 0%).
-
-## Command Sequence
-
-| # | Freq (MHz) | Command | Name | Direction | CTRL0 | CTRL1 | Data (hex) | Notes |
-|---|-----------|---------|------|-----------|-------|-------|------------|-------|
-| 1 | 868.95 | 0x00 | EXECUTE_REQUEST | AA9BFA -> EE8165 | 50 | 00 | 01E7D20020C80000 | Auth required. Payload: position D2=STOP?, 20C80000 (C800 = 100% closed) |
-| 2 | 868.95 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 6EC5276AC060 | Authentication response to challenge (for cmd 0x00) |
-| 3 | 868.25 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION, pos 0000 |
-| 4 | 868.25 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05, C800 = 100% closed, 0000 |
-| 5 | 868.25 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status query/command |
-| 6 | 868.25 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 078809D92735 | Auth response (for cmd 0x03) |
-| 7 | 868.95 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION, pos 0000 (repeat) |
-| 8 | 868.95 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | FDB9BF961F1C | Auth response |
-| 9 | 868.95 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05, C800 = 100% closed |
-| 10 | 869.85 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status query/command (repeat on new freq) |
-| 11 | 869.85 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | FE1B17AD1BB4 | Auth response (for cmd 0x03) |
-| 12 | 869.85 | 0x04 | PRIVATE_RESPONSE | EE8165 -> AA9BFA | 98 | 00 | 0500D200D8000000AA9BFA0120C80000 | Full status: 05=stopped, D2=STOP_POS, D8=FAVORITE, target AA9BFA, pos C800=100% |
-| 13 | 868.25 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION (final) |
-| 14 | 868.25 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05, C800 = 100% closed |
-
-## Observations
-
-- The cover is already at position C800 (100% closed / fully down). This command closes the tilt.
-- Command 0x00 (EXECUTE_REQUEST) initiates the tilt action, followed immediately by a 0x3D challenge response (authentication).
-- Command 0x0C (PRIVATE2) with data `D8000000` (D8 = FAVORITE_POSITION with value 0000) is sent multiple times across different frequencies (frequency hopping: 868.25, 868.95, 869.85 MHz).
-- Command 0x03 (PRIVATE) with data `03200100` appears to be a status request or tilt-specific command, also requiring authentication (followed by 0x3D).
-- Command 0x04 (PRIVATE_RESPONSE) returns full device status including current position, target address, and parameters.
-- All 0x0D responses contain `05C8000000` confirming position C800 (100% closed) with status byte 05 (stopped, bit 0 set).
-- CTRL0 values: 50 (execute), 0E (challenge response), 4C (private commands from controller), 8D (private response from device), 98 (private response with extended data).
+| Type | ID | Tilt |
+|------|-----|------|
+| VENETIAN_BLIND | 0x01 | Yes |
+| BLIND | 0x0A | Likely |
+| EXTERNAL_VENETIAN_BLIND | 0x11 | Confirmed |
+| LOUVRE_BLIND | 0x12 | Likely |
 
 ---
 
-# Open Tilt (100%)
+## Tilt Value Encoding
 
-Captured command sequence for opening the tilt of an already fully-down cover (position C800 = 100% closed) to tilt-open (tilt 100%). Cover remains down, only tilt changes.
-
-## Command Sequence
-
-| # | Freq (MHz) | Command | Name | Direction | CTRL0 | CTRL1 | Data (hex) | Notes |
-|---|-----------|---------|------|-----------|-------|-------|------------|-------|
-| 1 | 869.85 | 0x00 | EXECUTE_REQUEST | AA9BFA -> EE8165 | 50 | 00 | 01E7D20020000000 | Auth required. Target tilt position 0000 = 0% (fully open tilt) |
-| 2 | 869.85 | 0x3C | CHALLENGE_REQUEST | EE8165 -> AA9BFA | 0E | 00 | 573E98267E45 | Device sends challenge |
-| 3 | 869.85 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 61F01456D8F3 | Controller responds to challenge |
-| 4 | 868.95 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION, pos 0000 |
-| 5 | 868.95 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 71B8FDFF734E | Auth response (for cmd 0x0C) |
-| 6 | 868.95 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05=stopped, C800=100% closed |
-| 7 | 868.25 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status/tilt command |
-| 8 | 868.25 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 4B17B2E2C541 | Auth response (for cmd 0x03) |
-| 9 | 869.85 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION (repeat) |
-| 10 | 869.85 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 2D8BC430BEC3 | Auth response |
-| 11 | 869.85 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05=stopped, C800=100% closed |
-| 12 | 868.95 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status/tilt command (repeat) |
-| 13 | 868.95 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | F71F13C22A11 | Auth response (for cmd 0x03) |
-| 14 | 868.95 | 0x04 | PRIVATE_RESPONSE | EE8165 -> AA9BFA | 98 | 00 | 0500D200D8000000AA9BFA0120000000 | Full status: 05=stopped, pos C800, tilt target 0000=0% (open) |
-| 15 | 868.25 | 0x0C | PRIVATE2 | AA9BFA -> EE8165 | 4C | 00 | D8000000 | D8 = FAVORITE_POSITION (final) |
-| 16 | 868.25 | 0x3C | CHALLENGE_REQUEST | EE8165 -> AA9BFA | 0E | 00 | 0D333C6EBA46 | Device sends challenge |
-| 17 | 868.25 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | A5084B984F14 | Controller responds to challenge |
-| 18 | 868.25 | 0x0D | PRIVATE2_RESPONSE | EE8165 -> AA9BFA | 8D | 00 | 05C8000000 | ACK: 05=stopped, C800=100% closed |
-
-## Observations
-
-- The EXECUTE_REQUEST payload is `01E7D20020000000` — the key difference from close-tilt is the last 4 bytes: `00000000` (tilt open) vs `C8000000` (tilt closed).
-- This capture includes the full 0x3C CHALLENGE_REQUEST from the device (not seen in close-tilt capture, likely missed there).
-- The 0x04 PRIVATE_RESPONSE confirms: `0500D200D8000000AA9BFA0120000000` — last 4 bytes `00000000` = tilt target 0% (fully open), while cover position remains C800 (fully down).
-- Command 0x0C (PRIVATE2) with `D8000000` and 0x03 (PRIVATE) with `03200100` repeat across frequencies, same pattern as close-tilt.
-- The final 0x0C on frame 15 triggers a new 0x3C/0x3D challenge exchange before the 0x0D ACK — suggesting the device may periodically re-authenticate.
-
----
-
-# Comparison: Close Tilt vs Open Tilt
-
-| Aspect | Close Tilt (0%) | Open Tilt (100%) |
-|--------|----------------|-----------------|
-| EXECUTE_REQUEST data | `01E7D20020C80000` | `01E7D20020000000` |
-| Tilt target value | C800 (100% closed) | 0000 (0% = fully open) |
-| PRIVATE_RESPONSE tail | `...0120C80000` | `...0120000000` |
-| Cover position in responses | C800 (down) | C800 (down) |
-| Overall structure | Identical | Identical |
-
-The tilt position is encoded in the last 4 bytes of the EXECUTE_REQUEST payload (bytes 5-8): `C800` = closed, `0000` = open. The same value appears in the PRIVATE_RESPONSE (0x04) as the tilt target.
-
----
-
-# Set Position to 80% (No Tilt Change)
-
-Captured command sequence for moving the cover to 80% closed (position only, no tilt parameter). The cover moves from its current position to the target. Log is partial (capture cut short).
-
-## Command Sequence
-
-| # | Freq (MHz) | Command | Name | Direction | CTRL0 | CTRL1 | Data (hex) | Notes |
-|---|-----------|---------|------|-----------|-------|-------|------------|-------|
-| 1 | 868.25 | 0x00 | EXECUTE_REQUEST | AA9BFA -> EE8165 | 4E | 00 | 01E728000000 | Position-only command. Target 2800 = 80% closed (0x28=40 decimal, 40/0.5=80%) |
-| 2 | 868.25 | 0x3C | CHALLENGE_REQUEST | EE8165 -> AA9BFA | 0E | 00 | 004C39746259 | Device sends challenge |
-| 3 | 868.25 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | 5FA2688FEF6A | Controller responds to challenge |
-| 4 | 868.25 | 0x04 | PRIVATE_RESPONSE | EE8165 -> AA9BFA | 96 | 00 | 0480280014160006AA9BFA010000 | Status: 04=moving, target 2800=80%, current 1416=~40%?, originator AA9BFA |
-| 5 | 869.85 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status query (log ends here) |
-
-## Observations
-
-- **CTRL0 = 4E** on EXECUTE_REQUEST vs 50 in the tilt commands. This likely indicates a different command subtype (position-only vs position+tilt).
-- **Payload `01E728000000`** is only 6 bytes vs 8 bytes for tilt commands (`01E7D20020xxxx00`). The format differs:
-  - Position-only: `01 E7 28 00 00 00` — byte 2 = `28` (target position 0x2800 = 80%)
-  - Tilt commands: `01 E7 D2 00 20 xx xx 00` — byte 2 = `D2` (STOP_POSITION param), bytes 5-6 = tilt value
-- **0x04 PRIVATE_RESPONSE with CTRL0=96** (vs 98 in tilt commands): 14 bytes vs 16 bytes. Payload `0480280014160006AA9BFA010000`:
-  - `04` = status moving (not stopped, bit 0 clear)
-  - `80` = flags (CMD_PARAM_STATUS_EXPECTED set — device will send STATUS_UPDATE)
-  - `2800` = target position (80% closed)
-  - `1416` = current position (device in motion)
-  - `0006` = unknown (speed? timer?)
-  - `AA9BFA` = originator address
-  - `01` = unknown
-  - `0000` = tilt position (unchanged/not specified)
-- **No 0x0C (PRIVATE2)** commands seen — those only appear in tilt sequences.
-- The capture ends early (only 5 frames captured vs 14-18 for tilt commands).
-
----
-
-# Comparison: Position vs Tilt Commands
-
-| Aspect | Position Only (80%) | Tilt (open/close) |
-|--------|-------------------|-------------------|
-| EXECUTE_REQUEST CTRL0 | 4E | 50 |
-| EXECUTE_REQUEST size | 6 bytes | 8 bytes |
-| Payload byte 2 | Position value (0x28=80%) | D2 (STOP_POSITION param) |
-| Tilt value in payload | Not present | Bytes 5-6 (0000 or C800) |
-| PRIVATE_RESPONSE CTRL0 | 96 | 98 |
-| PRIVATE_RESPONSE size | 14 bytes | 16 bytes |
-| PRIVATE2 (0x0C) used | No | Yes (repeated with D8000000) |
-| Device status byte | 04 (moving) | 05 (stopped) |
-
-## EXECUTE_REQUEST Payload Format
+Tilt is encoded as **closed percentage** of `0xC800`:
 
 ```
-Position only (CTRL0=4E, 6 bytes):
-  01 E7 PP PP 00 00
-  PP PP = target position (big-endian, 0x0000=0%/open, 0xC800=100%/closed)
+tilt_hex = (100 - open_percent) * 0xC800 / 100
+```
 
-Position + Tilt (CTRL0=50, 8 bytes):
+| Open % | Hex  |
+|--------|------|
+| 0 (closed) | C800 |
+| 25 | 9600 |
+| 50 | 6400 |
+| 75 | 3200 |
+| 100 (open) | 0000 |
+
+---
+
+## Sending a Tilt Command (EXECUTE_REQUEST, cmd 0x00)
+
+```
+CTRL0 = 50, payload 8 bytes:
   01 E7 D2 00 20 TT TT 00
-  D2 = STOP_POSITION parameter marker
-  20 = separator/flag
-  TT TT = tilt value (0x0000=open, 0xC800=closed)
+
+  D2    = STOP_POSITION parameter marker (keeps current position)
+  20    = tilt parameter flag
+  TT TT = tilt value (closed %, big-endian)
+```
+
+Compare with position-only command:
+
+```
+CTRL0 = 4E, payload 6 bytes:
+  01 E7 PP PP 00 00
+
+  PP PP = target position (0x0000=open, 0xC800=closed)
 ```
 
 ---
 
-# Tilt to 25% at Position 80%
+## Status Request Differences
 
-Captured command sequence for setting tilt to 25% while the cover is at 80% closed. Partial capture.
+| Query | Data | Response CTRL0 | Response size | Includes tilt |
+|-------|------|----------------|---------------|---------------|
+| Basic | `030000` (3 bytes) | 96 | 14 bytes | Bytes [12-13] (may be zero) |
+| Tilt-aware | `03200100` (4 bytes) | 98 | 16 bytes | Bytes [13-14] (reliable) |
 
-## Command Sequence
-
-| # | Freq (MHz) | Command | Name | Direction | CTRL0 | CTRL1 | Data (hex) | Notes |
-|---|-----------|---------|------|-----------|-------|-------|------------|-------|
-| 1 | 868.95 | 0x00 | EXECUTE_REQUEST | AA9BFA -> EE8165 | 50 | 00 | 01E7D20020960000 | Tilt command. Target tilt 9600 = 75% closed (25% open) |
-| 2 | 868.95 | 0x04 | PRIVATE_RESPONSE | EE8165 -> AA9BFA | 96 | 00 | 0480D20027F90001AA9BFA010000 | Moving: target D200=?, current 27F9, originator AA9BFA |
-| 3 | 869.85 | 0x03 | PRIVATE | AA9BFA -> EE8165 | 4C | 00 | 03200100 | Status query |
-| 4 | 869.85 | 0x3D | CHALLENGE_RESPONSE | AA9BFA -> EE8165 | 0E | 00 | B936EE2A3074 | Auth response (for cmd 0x03) |
-
-## Observations
-
-- **Tilt value `9600`**: In the EXECUTE_REQUEST `01E7D20020960000`, bytes 5-6 = `9600`. Since C800 = 100% closed and 0000 = 0% (fully open), then 9600 = 0x9600/0xC800 = 75% closed = **25% open tilt**. This confirms tilt is expressed as "closed percentage" (inverted from user-facing "open" percentage).
-- **CTRL0 = 96 on 0x04 response** (14 bytes, not 16) — same as the position-only response format, not the 98/16-byte tilt format seen when cover is stationary. The device appears to be moving (status `04`, bit 0 clear).
-- **Response payload `0480D20027F90001AA9BFA010000`**:
-  - `04` = moving
-  - `80` = STATUS_EXPECTED flag
-  - `D200` = D2 parameter (STOP_POSITION) — matches the command
-  - `27F9` = current position in transit (~79.8% — close to the 80% target from previous move)
-  - `0001` = unknown
-  - `AA9BFA` = originator
-  - `01` = unknown
-  - `0000` = tilt (current or previous — not yet at target)
-- The 0x3C challenge was likely sent but not captured (or auth was cached from previous exchange). Only 0x3D response seen.
-- Capture ends early — likely more 0x0C/0x0D exchanges would follow.
-
-## Tilt Value Mapping
-
-| User-facing tilt | Hex value | Calculation |
-|-----------------|-----------|-------------|
-| 0% (closed) | C800 | 100% of C800 |
-| 25% (open) | 9600 | 75% of C800 |
-| 50% | 6400 | 50% of C800 |
-| 75% | 3200 | 25% of C800 |
-| 100% (fully open) | 0000 | 0% of C800 |
-
-Tilt is encoded as **closed percentage**: `tilt_hex = (100 - open_percent) * 0xC800 / 100`
+Use `03200100` for tilt-capable devices to get the full tilt value.
 
 ---
 
-# Tilt 25% at Position 80% — io_add Response
+## PRIVATE_RESPONSE Formats (cmd 0x04)
 
-Output from `io_add EE8165` (device already paired, requesting status via 0x03 PRIVATE):
+### 14-byte (CTRL0=96)
 
-## Command Sequence
-
-| # | Freq (MHz) | Command | Name | Direction | CTRL0 | CTRL1 | Data (hex) | Notes |
-|---|-----------|---------|------|-----------|-------|-------|------------|-------|
-| 1 | 868.95 | 0x03 | PRIVATE | 696969 -> EE8165 | 4B | 20 | 030000 | Status request from our controller |
-| 2 | 868.95 | 0x3C | CHALLENGE_REQUEST | EE8165 -> 696969 | 0E | 00 | DED10FD04E80 | Device challenge |
-| 3 | 868.95 | 0x3D | CHALLENGE_RESPONSE | 696969 -> EE8165 | 0E | 00 | FD79458949A6 | Controller auth response |
-| 4 | 868.95 | 0x04 | PRIVATE_RESPONSE | EE8165 -> 696969 | 96 | 00 | 05002800280A0000696969010000 | Stopped, pos 2800=80%, target 2800=80% |
-
-## Observations
-
-- Device type `0x11` = EXTERNAL_VENETIAN_BLIND, subtype `0x00`.
-- The 0x04 response is **14 bytes with CTRL0=96** — same format as position-only movement response.
-- **Response payload `05002800280A0000696969010000`**:
-  - `05` = stopped (bit 0 set)
-  - `00` = flags (no STATUS_EXPECTED)
-  - `2800` = target position (80% closed, matches `0x28 * 2 = 0x50 = 80`)
-  - `280A` = current position (should be 2800 but shows 280A — minor deviation or includes sub-position?)
-  - `0000` = timer/speed (zero, not moving)
-  - `696969` = originator (our controller address)
-  - `01` = unknown
-  - `0000` = **tilt value = 0000 = fully open (100% tilt open)**
-
-Wait — this contradicts! The test scenario says "tilt 25%" but the response shows `0000` (fully open tilt). Let me re-examine...
-
-Actually looking more carefully at the parsed position: bytes 2-3 = `2800` (target), bytes 4-5 = `280A`. If we follow the format from the tilt commands where the 14-byte response is:
-```
-[0]  status    = 05 (stopped)
-[1]  flags     = 00
-[2-3] target   = 2800 (position 80%)
-[4-5] current  = 280A (≈80%)
-[6-7] ????     = 0000
-[8-10] origin  = 696969
-[11] unknown   = 01
-[12-13] tilt   = 0000
-```
-
-The last 2 bytes `0000` would indicate tilt is fully open — **but this is the `io_add` status query using the basic `030000` request**. To get tilt info, send `03200100` instead.
-
----
-
-# PRIVATE_RESPONSE Formats (Corrected)
-
-## 14-byte response (CTRL0=96)
-
-Returned immediately after an EXECUTE_REQUEST (position or tilt command), or from a basic `030000` status query.
+Returned after EXECUTE_REQUEST or from basic `030000` query.
 
 ```
-Byte  Field                Example (position cmd)   Example (tilt cmd)
-[0]   status               04 (moving)              04 (moving)
-[1]   flags                80 (STATUS_EXPECTED)     80
-[2-3] target/marker        2800 (pos target 80%)    D200 (D2 = tilt marker)
-[4-5] current position     1416 (~40%)              27F9 (~80%)
-[6-7] timer/unknown        0006                     0001
-[8-10] originator          AA9BFA                   AA9BFA
-[11]  unknown              01                       01
-[12-13] tilt/zero          0000                     0000
+[0]    status byte (bit 0 = stopped)
+[1]    flags (bit 7 = STATUS_EXPECTED)
+[2-3]  target position OR D2 marker (if tilt operation)
+[4-5]  current position
+[6-7]  timer/unknown
+[8-10] originator node ID
+[11]   01
+[12-13] tilt (closed %) — may be 0000 if basic query
 ```
 
-- When `byte[2] == D2`: This is a tilt operation response. Bytes 2-3 are NOT a position target.
-  Current position is in bytes [4-5]. No tilt value is reported here.
-- When `byte[2] != D2`: Standard position response. Bytes [2-3] = target position, [4-5] = current position.
+When `byte[2] == 0xD2`: tilt operation in progress, bytes [2-3] are NOT a position target.
 
-## 16-byte response (CTRL0=98)
+### 16-byte (CTRL0=98)
 
-Returned in response to a `03200100` status query on tilt-capable devices.
+Returned in response to `03200100` on tilt-capable devices.
 
 ```
-Byte  Field                Example: close-tilt      Example: open-tilt
-[0]   status               05 (stopped)             05 (stopped)
-[1]   flags                00                       00
-[2]   D2 marker            D2                       D2
-[3]   zero                 00                       00
-[4-5] current position     D800 (*)                 D800 (*)
-[6-7] unknown              0000                     0000
-[8-10] originator          AA9BFA                   AA9BFA
-[11]  separator            01                       01
-[12]  tilt flag            20                       20
-[13-14] tilt (closed %)    C800 (100% closed)       0000 (0% closed = open)
-[15]  zero                 00                       00
+[0]    status byte (bit 0 = stopped)
+[1]    flags
+[2]    D2 marker
+[3]    00
+[4-5]  current position
+[6-7]  unknown
+[8-10] originator node ID
+[11]   01
+[12]   20 (tilt flag)
+[13-14] tilt (closed %)
+[15]   00
 ```
 
-(*) Note: In the Tahoma captures above, bytes [4-5] show `D800` which is the FAVORITE_POSITION
-marker from preceding PRIVATE2 exchanges. In practice with our controller (no PRIVATE2), bytes
-[4-5] contain the actual current position value (confirmed via testing: values like 2800=80% etc).
-
-**Tilt decoding**: `tilt_open_percent = 100 - (bytes[13-14] * 100 / 0xC800)`
-
----
-
-# Detecting Tilt Support
-
-Based on the captured data, tilt support can be determined by:
-
-1. **Device type** (from INFO2 response during discovery/add):
-   - `VENETIAN_BLIND (0x01)` — tilt supported
-   - `BLIND (0x0A)` — tilt likely supported
-   - `EXTERNAL_VENETIAN_BLIND (0x11)` — tilt supported (confirmed by this device)
-   - `LOUVRE_BLIND (0x12)` — tilt likely supported
-
-2. **CTRL0 in EXECUTE_REQUEST**:
-   - `4E` = position-only command (6 bytes payload)
-   - `50` = position+tilt command (8 bytes payload)
-
-3. **CTRL0 in PRIVATE_RESPONSE (0x04)**:
-   - `96` = 14-byte response (position info, basic)
-   - `98` = 16-byte response (includes explicit tilt value in extended format)
-
-4. **Status query format**:
-   - `030000` (3 bytes) = basic query, returns 14-byte response without tilt
-   - `03200100` (4 bytes) = tilt-aware query, returns 16-byte response with tilt value
+Tilt decoding: `tilt_open_percent = 100 - (bytes[13-14] * 100 / 0xC800)`

--- a/doc/tilted_cover.md
+++ b/doc/tilted_cover.md
@@ -35,9 +35,9 @@ tilt_hex = (100 - open_percent) * 0xC800 / 100
 
 ```
 CTRL0 = 50, payload 8 bytes:
-  01 E7 D2 00 20 TT TT 00
+  01 E7 D4 00 20 TT TT 00
 
-  D2    = STOP_POSITION parameter marker (keeps current position)
+  D4 00 = target position value or marker (D2 = stop, D4 = unknown/do nothing)
   20    = tilt parameter flag
   TT TT = tilt value (closed %, big-endian)
 ```
@@ -73,25 +73,24 @@ Returned after EXECUTE_REQUEST or from basic `030000` query.
 ```
 [0]    status byte (bit 0 = stopped)
 [1]    flags (bit 7 = STATUS_EXPECTED)
-[2-3]  target position OR D2 marker (if tilt operation)
+[2-3]  target position or marker (e.g. D2 00 = stopped at current, D4 00 = keep position for tilt)
 [4-5]  current position
 [6-7]  timer/unknown
 [8-10] originator node ID
 [11]   01
-[12-13] tilt (closed %) — may be 0000 if basic query
+[12-13] tilt (closed %) — unreliable (often 0000 after commands), do not use for tilt extraction
 ```
 
-When `byte[2] == 0xD2`: tilt operation in progress, bytes [2-3] are NOT a position target.
+When `byte[2] == 0xD2`: device stopped at current position (also seen on non-tilt-capable devices). When `byte[2] == 0xD4`: keep position (used during tilt operations). Bytes [2-3] are always treated as a target position value; marker values (D2, D4) simply exceed the valid position range.
 
 ### 16-byte (CTRL0=98)
 
-Returned in response to `03200100` on tilt-capable devices.
+Returned in response to `03200100` on tilt-capable devices. This is the only reliable source for tilt values.
 
 ```
 [0]    status byte (bit 0 = stopped)
 [1]    flags
-[2]    D2 marker
-[3]    00
+[2-3]  target position or marker (e.g. D2 00, D4 00, etc.)
 [4-5]  current position
 [6-7]  unknown
 [8-10] originator node ID

--- a/helpers/CmdLineIoTools.cpp
+++ b/helpers/CmdLineIoTools.cpp
@@ -746,6 +746,51 @@ void register_ioconfig(void)
     ESP_ERROR_CHECK(esp_console_cmd_register(&ioconfig_cmd));
 }
 
+// ******************* IO SET TILT ********************
+
+/// @brief Structure used by the 'io_tilt' command
+static struct
+{
+    struct arg_str *device_id;
+    struct arg_int *tilt;
+    struct arg_end *end;
+} iotilt_args;
+
+static int do_iotilt_cmd(int argc, char **argv)
+{
+    int nerrors = arg_parse(argc, argv, (void **)&iotilt_args);
+    if (nerrors != 0)
+    {
+        arg_print_errors(stderr, iotilt_args.end, argv[0]);
+        return 1;
+    }
+    if (iotilt_args.tilt->ival[0] >= 0 && iotilt_args.tilt->ival[0] <= 100)
+    {
+        sIoHome->SetDeviceTilt(iotilt_args.device_id->sval[0], iotilt_args.tilt->ival[0]);
+    }
+    else
+        ESP_LOGE(TAG, "Invalid value for <tilt>");
+    return 0;
+}
+
+void register_iotilt(void)
+{
+    iotilt_args.device_id = arg_str1(NULL, NULL, "<deviceid>", "ID of the device, 3 bytes (eg 112233)");
+    iotilt_args.tilt = arg_int1(NULL, NULL, "<tilt>", "Specify the tilt (0 = CLOSED to 100 = OPEN)");
+    iotilt_args.end = arg_end(2);
+
+    const esp_console_cmd_t iotilt_cmd = {
+        .command = "io_tilt",
+        .help = "Set an IO-HomeControl device to a specified tilt angle",
+        .hint = NULL,
+        .func = &do_iotilt_cmd,
+        .argtable = &iotilt_args,
+        .func_w_context = NULL,
+        .context = NULL};
+
+    ESP_ERROR_CHECK(esp_console_cmd_register(&iotilt_cmd));
+}
+
 // ******************* IO Register commands ********************
 
 void register_io_cmdline_tools(IoRts::IoRtsManager *io_rts_manager)
@@ -768,4 +813,5 @@ void register_io_cmdline_tools(IoRts::IoRtsManager *io_rts_manager)
     register_ioinvertdevice();
     register_iosendraw();
     register_ioconfig();
+    register_iotilt();
 }

--- a/helpers/DeviceStorage.cpp
+++ b/helpers/DeviceStorage.cpp
@@ -167,6 +167,9 @@ namespace Helpers
 
         iohome::IoDevice &dev = storedDevice.device;
         memset(&dev, 0, sizeof(iohome::IoDevice));
+        dev.position = iohome::UNKNOWN_POSITION;
+        dev.target = iohome::UNKNOWN_POSITION;
+        dev.tilt = iohome::UNKNOWN_POSITION;
 
         // Parse name
         cJSON *nameItem = cJSON_GetObjectItem(root, "name");

--- a/helpers/MqttHelpers.cpp
+++ b/helpers/MqttHelpers.cpp
@@ -16,9 +16,11 @@ static const std::string MQTT_CERTIFICATE_BEGIN = "-----BEGIN CERTIFICATE-----\n
 static const std::string MQTT_CERTIFICATE_END = "\n-----END CERTIFICATE-----";
 static const std::string MQTT_CLIENT_COMMAND_TOPIC = "/set";                   // command topic
 static const std::string MQTT_CLIENT_COMMAND_POSITION_TOPIC = "/set_position"; // position topic
+static const std::string MQTT_CLIENT_COMMAND_TILT_TOPIC = "/set_tilt";         // tilt topic
 static const std::string MQTT_CLIENT_COMMAND_FAV_POS_TOPIC = "/set_fav_pos";   // set favorite position topic
 static const std::string MQTT_CLIENT_STATE_TOPIC = "/state";                   // state topic
 static const std::string MQTT_CLIENT_POSITION_TOPIC = "/position";             // position topic
+static const std::string MQTT_CLIENT_TILT_TOPIC = "/tilt";                     // tilt topic
 static const std::string MQTT_CLIENT_DISCOVERY_TOPIC = "/config";              // discovery topic
 
 static const std::string MQTT_CLIENT_REBOOT_ID = "button_reboot";     // unique id and topic for "reboot" button
@@ -97,6 +99,8 @@ namespace Helpers
             msg_id = esp_mqtt_client_subscribe(client, topic.c_str(), 0);
             topic = mqttHelper->GetTopicPrefix() + "/+" + MQTT_CLIENT_COMMAND_FAV_POS_TOPIC;
             msg_id = esp_mqtt_client_subscribe(client, topic.c_str(), 0);
+            topic = mqttHelper->GetTopicPrefix() + "/+" + MQTT_CLIENT_COMMAND_TILT_TOPIC;
+            msg_id = esp_mqtt_client_subscribe(client, topic.c_str(), 0);
             break;
         }
         case MQTT_EVENT_DISCONNECTED:
@@ -121,7 +125,7 @@ namespace Helpers
             // Is it a command for us?
             const std::string topic_str(event->topic, event->topic_len);
             if (topic_str.starts_with(mqttHelper->GetTopicPrefix()) &&
-                (topic_str.ends_with(MQTT_CLIENT_COMMAND_TOPIC) || topic_str.ends_with(MQTT_CLIENT_COMMAND_POSITION_TOPIC) || topic_str.ends_with(MQTT_CLIENT_COMMAND_FAV_POS_TOPIC)))
+                (topic_str.ends_with(MQTT_CLIENT_COMMAND_TOPIC) || topic_str.ends_with(MQTT_CLIENT_COMMAND_POSITION_TOPIC) || topic_str.ends_with(MQTT_CLIENT_COMMAND_FAV_POS_TOPIC) || topic_str.ends_with(MQTT_CLIENT_COMMAND_TILT_TOPIC)))
             {
                 size_t id_len = 0;
                 if (topic_str.ends_with(MQTT_CLIENT_COMMAND_TOPIC))
@@ -130,6 +134,8 @@ namespace Helpers
                     id_len = topic_str.length() - mqttHelper->GetTopicPrefix().length() - MQTT_CLIENT_COMMAND_POSITION_TOPIC.length() - 1;
                 else if (topic_str.ends_with(MQTT_CLIENT_COMMAND_FAV_POS_TOPIC))
                     id_len = topic_str.length() - mqttHelper->GetTopicPrefix().length() - MQTT_CLIENT_COMMAND_FAV_POS_TOPIC.length() - 1;
+                else if (topic_str.ends_with(MQTT_CLIENT_COMMAND_TILT_TOPIC))
+                    id_len = topic_str.length() - mqttHelper->GetTopicPrefix().length() - MQTT_CLIENT_COMMAND_TILT_TOPIC.length() - 1;
                 if (id_len > 0)
                 {
                     std::string entity_id = topic_str.substr(mqttHelper->GetTopicPrefix().length() + 1, id_len);
@@ -348,6 +354,16 @@ namespace Helpers
                             {
                                 // ESP_LOGI(TAG, "Received 'set favorite position' for device %s", deviceID.c_str());
                                 mqttHelper->GetIoRtsManager()->mIoHome->SetDeviceToFavoritePosition(deviceID);
+                            }
+                            else if (topic_str.ends_with(MQTT_CLIENT_COMMAND_TILT_TOPIC)) // it should be a tilt between 0 and 100
+                            {
+                                float tilt = strtof(command.c_str(), NULL);
+                                if (tilt >= (float)0.0 && tilt <= (float)100.0)
+                                {
+                                    mqttHelper->GetIoRtsManager()->mIoHome->SetDeviceTilt(deviceID, (uint8_t)tilt);
+                                }
+                                else
+                                    ESP_LOGE(TAG, "Received command %s for device %s -> invalid tilt!", command.c_str(), deviceID.c_str());
                             }
                             else
                             {
@@ -673,6 +689,8 @@ namespace Helpers
                         std::string device_state_topic = GetTopicPrefix() + "/" + device_id + MQTT_CLIENT_STATE_TOPIC;
                         std::string device_position_topic = GetTopicPrefix() + "/" + device_id + MQTT_CLIENT_POSITION_TOPIC;
                         std::string device_cmd_position_topic = GetTopicPrefix() + "/" + device_id + MQTT_CLIENT_COMMAND_POSITION_TOPIC;
+                        std::string device_tilt_topic = GetTopicPrefix() + "/" + device_id + MQTT_CLIENT_TILT_TOPIC;
+                        std::string device_cmd_tilt_topic = GetTopicPrefix() + "/" + device_id + MQTT_CLIENT_COMMAND_TILT_TOPIC;
                         std::string device_cmd_fav_pos_topic = GetTopicPrefix() + "/" + device_id + MQTT_CLIENT_COMMAND_FAV_POS_TOPIC;
                         std::string device_plateform;
                         cmp = cJSON_AddObjectToObject(cmps, device_id.c_str());
@@ -714,6 +732,16 @@ namespace Helpers
                                     }
                                     error = error || (cJSON_AddStringToObject(cmp, "position_topic", device_position_topic.c_str()) == NULL);         // position_topic
                                     error = error || (cJSON_AddStringToObject(cmp, "set_position_topic", device_cmd_position_topic.c_str()) == NULL); // set_position_topic
+                                    // add tilt topics if device supports tilt
+                                    if (iohome::deviceTypeSupportsTilt(it->second.info.device_type))
+                                    {
+                                        error = error || (cJSON_AddStringToObject(cmp, "tilt_status_topic", device_tilt_topic.c_str()) == NULL);       // tilt_status_topic
+                                        error = error || (cJSON_AddStringToObject(cmp, "tilt_command_topic", device_cmd_tilt_topic.c_str()) == NULL);  // tilt_command_topic
+                                        error = error || (cJSON_AddNumberToObject(cmp, "tilt_closed_value", 0) == NULL);                              // tilt_closed_value
+                                        error = error || (cJSON_AddNumberToObject(cmp, "tilt_opened_value", 100) == NULL);                            // tilt_opened_value
+                                        error = error || (cJSON_AddNumberToObject(cmp, "tilt_min", 0) == NULL);                                      // tilt_min
+                                        error = error || (cJSON_AddNumberToObject(cmp, "tilt_max", 100) == NULL);                                    // tilt_max
+                                    }
                                     // add device_class https://www.home-assistant.io/integrations/cover/#device_class
                                     std::string type = "shutter";
                                     switch (it->second.info.device_type)
@@ -876,6 +904,11 @@ namespace Helpers
                 // device is marked as deleted, send empty messages to remove all retained messages for this device
                 esp_mqtt_client_publish(mMqttClientHandle, stateTopic.c_str(), NULL, 0, 0, 1);
                 esp_mqtt_client_publish(mMqttClientHandle, positionTopic.c_str(), NULL, 0, 0, 1);
+                if (iohome::deviceTypeSupportsTilt(device->second.info.device_type))
+                {
+                    std::string tiltTopic = GetTopicPrefix() + "/" + MQTT_CLIENT_PREFIX_IO + device->first + MQTT_CLIENT_TILT_TOPIC;
+                    esp_mqtt_client_publish(mMqttClientHandle, tiltTopic.c_str(), NULL, 0, 0, 1);
+                }
                 return;
             }
             switch (device->second.info.device_type)
@@ -925,6 +958,13 @@ namespace Helpers
                             data = device->second.info.is_openclose_inverted ? "opening" : "closing";
                     }
                     esp_mqtt_client_publish(mMqttClientHandle, stateTopic.c_str(), data.c_str(), 0, 0, 1);
+                    // send tilt if device supports it
+                    if (iohome::deviceTypeSupportsTilt(device->second.info.device_type) && device->second.tilt != UNKNOWN_POSITION)
+                    {
+                        std::string tiltTopic = GetTopicPrefix() + "/" + MQTT_CLIENT_PREFIX_IO + device->first + MQTT_CLIENT_TILT_TOPIC;
+                        data = std::to_string((int)device->second.tilt);
+                        esp_mqtt_client_publish(mMqttClientHandle, tiltTopic.c_str(), data.c_str(), 0, 0, 1);
+                    }
                 }
                 else
                 {

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -1557,74 +1557,42 @@ namespace iohome
         deviceIt->second.is_stopped = (statusFrame.data[0] & CMD_PARAM_STATUS_STOPPED) ? true : false;
         deviceIt->second.last_status_timestamp = esp_timer_get_time();
 
-        // Check if byte[2] is the D2 (STOP_POSITION) parameter marker
-        // When D2 is present, it means the last operation was tilt-related and bytes 2-3 are NOT a target position
-        bool isTiltResponse = (statusFrame.data[2] == CMD_PARAM_POSITION_STOP);
-
-        if (statusFrame.data_len >= 16 && isTiltResponse)
+        // [0] status, [1] flags, [2-3] target position or marker (D2=stop, D4=do nothing),
+        // [4-5] current position, [6-7] timer/unknown, [8-10] originator, [11] 01
+        uint16_t tmpTargetPos = statusFrame.data[2] << 8 | statusFrame.data[3];
+        uint16_t tmpCurrentPos = statusFrame.data[4] << 8 | statusFrame.data[5];
+        if (tmpTargetPos <= CMD_PARAM_STATUS_POS_MAX)
+          deviceIt->second.target = tmpTargetPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
+        else if (deviceIt->second.is_stopped && tmpCurrentPos <= CMD_PARAM_STATUS_POS_MAX)
+          deviceIt->second.target = tmpCurrentPos * 100.0 / CMD_PARAM_STATUS_POS_MAX; // Marker value (D2/D4), use current as target
+        else
+          deviceIt->second.target = UNKNOWN_POSITION;
+        if (tmpCurrentPos <= CMD_PARAM_STATUS_POS_MAX)
+          deviceIt->second.position = tmpCurrentPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
+        else
         {
-          // 16-byte tilt-extended response format (from 03200100 status query):
-          // [0] status, [1] flags, [2] D2, [3] 00, [4-5] current position,
-          // [6-7] unknown, [8-10] originator, [11] 01, [12] 20, [13-14] tilt value, [15] 00
-          uint16_t tmpCurrentPos = statusFrame.data[4] << 8 | statusFrame.data[5];
-          if (tmpCurrentPos <= CMD_PARAM_STATUS_POS_MAX)
+          // Current position is unknown... let's try to guess it
+          if (deviceIt->second.is_stopped)
           {
-            deviceIt->second.position = tmpCurrentPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
-            if (deviceIt->second.is_stopped)
-              deviceIt->second.target = deviceIt->second.position; // Tilt operation complete, position target = current
+            if (tmpTargetPos <= CMD_PARAM_STATUS_POS_MAX)
+              deviceIt->second.position = deviceIt->second.target;
+            else
+              deviceIt->second.position = UNKNOWN_POSITION;
           }
-          uint16_t tmpTiltClosed = statusFrame.data[13] << 8 | statusFrame.data[14];
-          if (tmpTiltClosed <= CMD_PARAM_STATUS_POS_MAX)
-            deviceIt->second.tilt = 100.0 - (tmpTiltClosed * 100.0 / CMD_PARAM_STATUS_POS_MAX); // Convert from "closed %" to "open %"
-          else
-            deviceIt->second.tilt = UNKNOWN_POSITION;
         }
-        else if (!isTiltResponse)
+
+        // Extract tilt value from 16-byte tilt-extended response only (from 03200100 query)
+        // 14-byte responses have unreliable tilt data (often 0000 which is ambiguous)
+        if (deviceTypeSupportsTilt(deviceIt->second.info.device_type))
         {
-          // Standard 14-byte position response format:
-          // [0] status, [1] flags, [2-3] target position, [4-5] current position,
-          // [6-7] timer, [8-10] originator, [11] 01, [12-13] tilt (closed %) for tilt devices, else zero
-          uint16_t tmpTargetPos = statusFrame.data[2] << 8 | statusFrame.data[3];
-          uint16_t tmpCurrentPos = statusFrame.data[4] << 8 | statusFrame.data[5];
-          if (tmpTargetPos <= CMD_PARAM_STATUS_POS_MAX)
-            deviceIt->second.target = tmpTargetPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
-          else
-            deviceIt->second.target = UNKNOWN_POSITION;
-          if (tmpCurrentPos <= CMD_PARAM_STATUS_POS_MAX)
-            deviceIt->second.position = tmpCurrentPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
-          else
+          if (statusFrame.data_len >= 16)
           {
-            // Current position is unknown... let's try to guess it
-            if (deviceIt->second.is_stopped)
-            {
-              if (tmpTargetPos <= CMD_PARAM_STATUS_POS_MAX)
-                deviceIt->second.position = deviceIt->second.target;
-              else
-                deviceIt->second.position = UNKNOWN_POSITION;
-            }
-          }
-          // Extract tilt from bytes [12-13] for tilt-capable devices
-          if (statusFrame.data_len >= 14 && deviceTypeSupportsTilt(deviceIt->second.info.device_type))
-          {
-            uint16_t tmpTiltClosed = statusFrame.data[12] << 8 | statusFrame.data[13];
+            // 16-byte tilt-extended response: tilt at [13-14]
+            uint16_t tmpTiltClosed = statusFrame.data[13] << 8 | statusFrame.data[14];
             if (tmpTiltClosed <= CMD_PARAM_STATUS_POS_MAX)
               deviceIt->second.tilt = 100.0 - (tmpTiltClosed * 100.0 / CMD_PARAM_STATUS_POS_MAX);
             else
               deviceIt->second.tilt = UNKNOWN_POSITION;
-          }
-        }
-        else
-        {
-          // 14-byte tilt response (byte[2]=D2, data_len < 16): immediate response to tilt command
-          // [0] status, [1] flags, [2] D2, [3] 00, [4-5] current position,
-          // [6-7] unknown, [8-10] originator, [11] 01, [12-13] unknown/zero
-          // Don't overwrite target from bytes 2-3 (D2 marker, not a position)
-          uint16_t tmpCurrentPos = statusFrame.data[4] << 8 | statusFrame.data[5];
-          if (tmpCurrentPos <= CMD_PARAM_STATUS_POS_MAX)
-          {
-            deviceIt->second.position = tmpCurrentPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
-            if (deviceIt->second.is_stopped)
-              deviceIt->second.target = deviceIt->second.position; // Tilt operation complete, position target = current
           }
         }
 

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -656,7 +656,12 @@ namespace iohome
             {
               IoFrame request;
               IoFrame response;
-              if (create_getstatus03_request(request, mOwnNodeId, it->second.info.node_id) && SendAndReceive(request, response, FREQUENCY_CHANNEL_2))
+              bool reqOk;
+              if (deviceTypeSupportsTilt(it->second.info.device_type))
+                reqOk = create_getstatus03_tilt_request(request, mOwnNodeId, it->second.info.node_id);
+              else
+                reqOk = create_getstatus03_request(request, mOwnNodeId, it->second.info.node_id);
+              if (reqOk && SendAndReceive(request, response, FREQUENCY_CHANNEL_2))
               {
                 UpdateDeviceStatus(response);
               }
@@ -691,6 +696,7 @@ namespace iohome
       device.is_deleted = false;
       device.position = UNKNOWN_POSITION;
       device.target = UNKNOWN_POSITION;
+      device.tilt = UNKNOWN_POSITION;
       HexStringToBuff(deviceID, device.info.node_id, NODE_ID_SIZE);
       sDeviceMap.insert({deviceID, device});
     }
@@ -911,6 +917,70 @@ namespace iohome
       IO_LOGE("SetDevicePosition: failed to take mutex!");
       return false;
     }
+  }
+
+  bool IoHomeControl::SetDeviceTilt(const std::string &deviceID, uint8_t tilt)
+  {
+    if (!mInitialized || !mReceiving || mPassiveMode)
+    {
+      IO_LOGE("SetDeviceTilt: invalid state! (not initialized or not listening or passive mode)");
+      return false;
+    }
+    std::map<std::string, IoDevice>::iterator it = sDeviceMap.find(deviceID);
+    if (it == sDeviceMap.end())
+    {
+      IO_LOGE("SetDeviceTilt: no device found in list!");
+      return false;
+    }
+    else if (it->second.is_deleted)
+    {
+      IO_LOGE("SetDeviceTilt: device is marked as deleted, add it before using it!");
+      return false;
+    }
+    if (!deviceTypeSupportsTilt(it->second.info.device_type))
+    {
+      IO_LOGE("SetDeviceTilt: device ({}) doesn't support tilt!", deviceID);
+      return false;
+    }
+    if (tilt > 100)
+    {
+      IO_LOGE("SetDeviceTilt: invalid tilt value! (0-100)");
+      return false;
+    }
+    IO_LOGI("Setting tilt to {}%", tilt);
+    if (xSemaphoreTake(sMutex, MUTEX_MAX_WAIT_TICKS))
+    {
+      IoFrame request;
+      IoFrame response;
+      bool ret = false;
+      UBaseType_t currentPriority = uxTaskPriorityGet(NULL);
+      vTaskPrioritySet(NULL, IO_FRAME_PROCESSING_TASK); // change task priority to higher!
+      if (create_execute_tilt_request(request, mOwnNodeId, it->second.info.node_id, true, tilt) && SendAndReceive(request, response, FREQUENCY_CHANNEL_2))
+      {
+        UpdateDeviceStatus(response);
+        ret = true;
+      }
+      else
+      {
+        IO_LOGE("SetDeviceTilt: failed to send request!");
+      }
+      vTaskPrioritySet(NULL, currentPriority); // restore task priority
+      xSemaphoreGive(sMutex);
+      return ret;
+    }
+    else
+    {
+      IO_LOGE("SetDeviceTilt: failed to take mutex!");
+      return false;
+    }
+  }
+
+  bool IoHomeControl::isDeviceTiltSupported(const std::string &deviceID)
+  {
+    std::map<std::string, IoDevice>::iterator it = sDeviceMap.find(deviceID);
+    if (it == sDeviceMap.end())
+      return false;
+    return deviceTypeSupportsTilt(it->second.info.device_type);
   }
 
   bool IoHomeControl::OpenDevice(const std::string &deviceID, bool quiet)
@@ -1486,27 +1556,78 @@ namespace iohome
       {
         deviceIt->second.is_stopped = (statusFrame.data[0] & CMD_PARAM_STATUS_STOPPED) ? true : false;
         deviceIt->second.last_status_timestamp = esp_timer_get_time();
-        uint16_t tmpTargetPos = statusFrame.data[2] << 8 | statusFrame.data[3];
-        uint16_t tmpCurrentPos = statusFrame.data[4] << 8 | statusFrame.data[5];
-        if (tmpTargetPos <= CMD_PARAM_STATUS_POS_MAX)
-          deviceIt->second.target = tmpTargetPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
-        else
-          deviceIt->second.target = UNKNOWN_POSITION; // No clue...
-        if (tmpCurrentPos <= CMD_PARAM_STATUS_POS_MAX)
-          deviceIt->second.position = tmpCurrentPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
+
+        // Check if byte[2] is the D2 (STOP_POSITION) parameter marker
+        // When D2 is present, it means the last operation was tilt-related and bytes 2-3 are NOT a target position
+        bool isTiltResponse = (statusFrame.data[2] == CMD_PARAM_POSITION_STOP);
+
+        if (statusFrame.data_len >= 16 && isTiltResponse)
+        {
+          // 16-byte tilt-extended response format (from 03200100 status query):
+          // [0] status, [1] flags, [2] D2, [3] 00, [4-5] current position,
+          // [6-7] unknown, [8-10] originator, [11] 01, [12] 20, [13-14] tilt value, [15] 00
+          uint16_t tmpCurrentPos = statusFrame.data[4] << 8 | statusFrame.data[5];
+          if (tmpCurrentPos <= CMD_PARAM_STATUS_POS_MAX)
+          {
+            deviceIt->second.position = tmpCurrentPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
+            if (deviceIt->second.is_stopped)
+              deviceIt->second.target = deviceIt->second.position; // Tilt operation complete, position target = current
+          }
+          uint16_t tmpTiltClosed = statusFrame.data[13] << 8 | statusFrame.data[14];
+          if (tmpTiltClosed <= CMD_PARAM_STATUS_POS_MAX)
+            deviceIt->second.tilt = 100.0 - (tmpTiltClosed * 100.0 / CMD_PARAM_STATUS_POS_MAX); // Convert from "closed %" to "open %"
+          else
+            deviceIt->second.tilt = UNKNOWN_POSITION;
+        }
+        else if (!isTiltResponse)
+        {
+          // Standard 14-byte position response format:
+          // [0] status, [1] flags, [2-3] target position, [4-5] current position,
+          // [6-7] timer, [8-10] originator, [11] 01, [12-13] tilt (closed %) for tilt devices, else zero
+          uint16_t tmpTargetPos = statusFrame.data[2] << 8 | statusFrame.data[3];
+          uint16_t tmpCurrentPos = statusFrame.data[4] << 8 | statusFrame.data[5];
+          if (tmpTargetPos <= CMD_PARAM_STATUS_POS_MAX)
+            deviceIt->second.target = tmpTargetPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
+          else
+            deviceIt->second.target = UNKNOWN_POSITION;
+          if (tmpCurrentPos <= CMD_PARAM_STATUS_POS_MAX)
+            deviceIt->second.position = tmpCurrentPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
+          else
+          {
+            // Current position is unknown... let's try to guess it
+            if (deviceIt->second.is_stopped)
+            {
+              if (tmpTargetPos <= CMD_PARAM_STATUS_POS_MAX)
+                deviceIt->second.position = deviceIt->second.target;
+              else
+                deviceIt->second.position = UNKNOWN_POSITION;
+            }
+          }
+          // Extract tilt from bytes [12-13] for tilt-capable devices
+          if (statusFrame.data_len >= 14 && deviceTypeSupportsTilt(deviceIt->second.info.device_type))
+          {
+            uint16_t tmpTiltClosed = statusFrame.data[12] << 8 | statusFrame.data[13];
+            if (tmpTiltClosed <= CMD_PARAM_STATUS_POS_MAX)
+              deviceIt->second.tilt = 100.0 - (tmpTiltClosed * 100.0 / CMD_PARAM_STATUS_POS_MAX);
+            else
+              deviceIt->second.tilt = UNKNOWN_POSITION;
+          }
+        }
         else
         {
-          // Current position is unknown... let's try to guess it
-          if (deviceIt->second.is_stopped)
+          // 14-byte tilt response (byte[2]=D2, data_len < 16): immediate response to tilt command
+          // [0] status, [1] flags, [2] D2, [3] 00, [4-5] current position,
+          // [6-7] unknown, [8-10] originator, [11] 01, [12-13] unknown/zero
+          // Don't overwrite target from bytes 2-3 (D2 marker, not a position)
+          uint16_t tmpCurrentPos = statusFrame.data[4] << 8 | statusFrame.data[5];
+          if (tmpCurrentPos <= CMD_PARAM_STATUS_POS_MAX)
           {
-            // let's use target position (if valid) as we have reached it
-            if (tmpTargetPos <= CMD_PARAM_STATUS_POS_MAX)
-              deviceIt->second.position = deviceIt->second.target;
-            else
-              deviceIt->second.position = UNKNOWN_POSITION; // No clue...
+            deviceIt->second.position = tmpCurrentPos * 100.0 / CMD_PARAM_STATUS_POS_MAX;
+            if (deviceIt->second.is_stopped)
+              deviceIt->second.target = deviceIt->second.position; // Tilt operation complete, position target = current
           }
-          // else: we will see when target will be reached. Keep current value for now!
         }
+
         // When do we want to update next time?
         if (deviceIt->second.is_stopped)
         {
@@ -1646,9 +1767,16 @@ namespace iohome
         expectedResponseID = CMD_GET_GENERAL_INFO3_RESPONSE;
         break;
       case CMD_PRIVATE:
-        ret = create_getstatus03_request(request, mOwnNodeId, tmpDeviceId);
+      {
+        // Use tilt-extended status request for devices that support tilt
+        auto it = sDeviceMap.find(deviceID);
+        if (it != sDeviceMap.end() && deviceTypeSupportsTilt(it->second.info.device_type))
+          ret = create_getstatus03_tilt_request(request, mOwnNodeId, tmpDeviceId);
+        else
+          ret = create_getstatus03_request(request, mOwnNodeId, tmpDeviceId);
         expectedResponseID = CMD_PRIVATE_RESPONSE;
         break;
+      }
       default:
         break;
       }

--- a/io-homecontrol/IoHomeControl.hpp
+++ b/io-homecontrol/IoHomeControl.hpp
@@ -115,6 +115,17 @@ namespace iohome
     /// @return true on success, false on error
     bool SetDevicePosition(const std::string &deviceID, uint8_t position, bool quiet = false);
 
+    /// @brief Set tilt of an actuator (e.g., venetian blind)
+    /// @param deviceID Device ID (6 characters as hex representation of the 3 bytes, eg "112233")
+    /// @param tilt Tilt value (0 = closed, 100 = fully open)
+    /// @return true on success, false on error
+    bool SetDeviceTilt(const std::string &deviceID, uint8_t tilt);
+
+    /// @brief Check if device supports tilt based on device type
+    /// @param deviceID Device ID (6 characters as hex representation of the 3 bytes, eg "112233")
+    /// @return true if device supports tilt, false otherwise
+    bool isDeviceTiltSupported(const std::string &deviceID);
+
     /// @brief Set an actuator (e.g., blind, shutter) to its favorite position (like "My" button on Somfy remote)
     /// @param deviceID Device ID (6 characters as hex representation of the 3 bytes, eg "112233")
     /// @return

--- a/io-homecontrol/protocol/iohome_commands.cpp
+++ b/io-homecontrol/protocol/iohome_commands.cpp
@@ -46,6 +46,34 @@ namespace iohome
         return set_command(frame, CMD_EXECUTE_REQUEST, data, param_len);
     }
 
+    bool create_execute_tilt_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id, bool is_low_power, uint8_t tilt_percent)
+    {
+        // Initialize frame
+        init_frame(frame, true, true, false, is_low_power);
+
+        // Set source and destination
+        set_destination(frame, dst_node_id);
+        set_source(frame, own_node_id);
+
+        // Set data - tilt command uses 8-byte payload with D2 marker
+        // Format: 01 E7 D2 00 20 TT TT 00
+        // Where TTTT = tilt as "closed percentage" of 0xC800
+        // tilt_percent is "open" percentage (0=closed, 100=open), so we invert it
+        uint8_t data[8];
+        data[0] = 0x01; // Command Originator => User Remote Control
+        data[1] = 0xE7; // ACEI => same as captured tilt commands
+        data[2] = CMD_PARAM_POSITION_STOP; // 0xD2 = STOP_POSITION parameter marker
+        data[3] = 0x00;
+        data[4] = 0x20; // separator/flag (as observed in captures)
+        // Convert open percentage to closed value: closed_value = (100 - tilt_percent) * 0xC800 / 100
+        uint16_t tilt_value = (uint16_t)((100 - tilt_percent) * CMD_PARAM_STATUS_POS_MAX / 100);
+        data[5] = (tilt_value >> 8) & 0xFF;
+        data[6] = tilt_value & 0xFF;
+        data[7] = 0x00;
+
+        return set_command(frame, CMD_EXECUTE_REQUEST, data, 8);
+    }
+
     bool create_getstatus03_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id)
     {
         // Initialize frame
@@ -59,6 +87,22 @@ namespace iohome
         uint8_t data[3] = {0x03, 0x00, 0x00};
 
         return set_command(frame, CMD_PRIVATE, data, 3);
+    }
+
+    bool create_getstatus03_tilt_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id)
+    {
+        // Initialize frame - same as regular status but with extended data to request tilt info
+        init_frame(frame, true, true, false, true);
+
+        // Set source and destination
+        set_destination(frame, dst_node_id);
+        set_source(frame, own_node_id);
+
+        // Set data: 03 20 01 00 - requests tilt-extended status response (16 bytes)
+        // This is what the Tahoma sends to get tilt info from venetian blind devices
+        uint8_t data[4] = {0x03, 0x20, 0x01, 0x00};
+
+        return set_command(frame, CMD_PRIVATE, data, 4);
     }
 
     bool create_discovery_request(IoFrame &frame, const uint8_t *own_node_id)

--- a/io-homecontrol/protocol/iohome_commands.cpp
+++ b/io-homecontrol/protocol/iohome_commands.cpp
@@ -62,7 +62,7 @@ namespace iohome
         uint8_t data[8];
         data[0] = 0x01; // Command Originator => User Remote Control
         data[1] = 0xE7; // ACEI => same as captured tilt commands
-        data[2] = CMD_PARAM_POSITION_STOP; // 0xD2 = STOP_POSITION parameter marker
+        data[2] = CMD_PARAM_POSITION_UNKNOWN; // 0xD4 = CMD_PARAM_POSITION_UNKNOWN parameter marker -> should not stop/change pos if moving
         data[3] = 0x00;
         data[4] = 0x20; // separator/flag (as observed in captures)
         // Convert open percentage to closed value: closed_value = (100 - tilt_percent) * 0xC800 / 100

--- a/io-homecontrol/protocol/iohome_commands.hpp
+++ b/io-homecontrol/protocol/iohome_commands.hpp
@@ -18,12 +18,28 @@ namespace iohome
     /// @return true on success
     bool create_execute_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id, bool is_low_power, uint8_t position, bool quiet = false);
 
+    /// @brief Create an execute tilt IO Frame (0x00) - Sets tilt position without changing cover position
+    /// @param frame Output IoFrame structure
+    /// @param own_node_id Source node ID (3 bytes)
+    /// @param dst_node_id Destination node ID (3 bytes) for output frame to create
+    /// @param is_low_power 'Low power' flag to set
+    /// @param tilt_percent Tilt percentage (0 = closed, 100 = fully open)
+    /// @return true on success
+    bool create_execute_tilt_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id, bool is_low_power, uint8_t tilt_percent);
+
     /// @brief Create a GetStatus IO Frame (0x03)
     /// @param frame Output IoFrame structure
     /// @param own_node_id Source node ID (3 bytes)
     /// @param dst_node_id Destination node ID (3 bytes) for output frame to create
     /// @return true on success
     bool create_getstatus03_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id);
+
+    /// @brief Create a GetStatus IO Frame (0x03) with tilt info request
+    /// @param frame Output IoFrame structure
+    /// @param own_node_id Source node ID (3 bytes)
+    /// @param dst_node_id Destination node ID (3 bytes) for output frame to create
+    /// @return true on success
+    bool create_getstatus03_tilt_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id);
 
     /// @brief Create a Discovery IO Frame (0x28)
     /// @param frame Output IoFrame structure

--- a/io-homecontrol/protocol/iohome_device.hpp
+++ b/io-homecontrol/protocol/iohome_device.hpp
@@ -28,9 +28,27 @@ namespace iohome
         IoDeviceInformation info;             // Device static information (no changes during use)
         float position;                       // Position between 0.0 and 100.0 or UNKNOWN_POSITION if unknown. 0 is open / 0% closed / light on / switch on, 100 is 100% closed / light off / switch off.
         float target;                         // Position between 0.0 and 100.0 or UNKNOWN_POSITION if unknown. 0 is open / 0% closed / light on / switch on, 100 is 100% closed / light off / switch off.
+        float tilt;                           // Tilt between 0.0 (closed) and 100.0 (fully open) or UNKNOWN_POSITION if unknown/unsupported.
         bool is_stopped;                      // true if stopped, false if moving.
         bool is_deleted;                      // true if device has been deleted (will not be created at next boot)
         int64_t last_status_timestamp;        // Timestamp of the last received status, in us (use esp_timer_get_time() to fill and compare to local date&time!)
         int64_t next_status_update_timestamp; // Timestamp of the next planned status update, in us (use esp_timer_get_time() to fill and compare to local date&time!)
     };
+
+    /// @brief Check if a device type supports tilt control
+    /// @param type Device type
+    /// @return true if the device type supports tilt
+    inline bool deviceTypeSupportsTilt(DeviceType type)
+    {
+        switch (type)
+        {
+        case DeviceType::VENETIAN_BLIND:
+        case DeviceType::EXTERNAL_VENETIAN_BLIND:
+        case DeviceType::LOUVRE_BLIND:
+        case DeviceType::BLIND:
+            return true;
+        default:
+            return false;
+        }
+    }
 } // namespace iohome

--- a/main/IoRtsManager.cpp
+++ b/main/IoRtsManager.cpp
@@ -41,9 +41,9 @@ namespace IoRts
 
     static void deviceStatusCallback(const std::string deviceID, const iohome::IoDevice &device)
     {
-        ESP_LOGI(TAG, "Callback received device status for %s: %s (0x%02X/0x%02X) / Position %.1f / Target %0.1f / Moving: %s / Inverted: %s / Deleted: %s",
+        ESP_LOGI(TAG, "Callback received device status for %s: %s (0x%02X/0x%02X) / Position %.1f / Target %0.1f / Tilt %.1f / Moving: %s / Inverted: %s / Deleted: %s",
                  deviceID.c_str(), device.info.name, device.info.device_type, device.info.device_subtype,
-                 device.position, device.target,
+                 device.position, device.target, device.tilt,
                  device.is_stopped ? "No" : "Yes", device.info.is_openclose_inverted ? "Yes" : "No", device.is_deleted ? "Yes" : "No");
         if (sIoRtsManager == nullptr)
             return;
@@ -100,6 +100,7 @@ namespace IoRts
                 it->second.next_status_update_timestamp = device.next_status_update_timestamp;
                 it->second.position = device.position;
                 it->second.target = device.target;
+                it->second.tilt = device.tilt;
                 // Update storage when static device info changed (name, type, ...)
                 if (sendDiscovery)
                 {


### PR DESCRIPTION
## Summary

- Full tilt control for io-homecontrol venetian blind devices (types 0x01, 0x0A, 0x11, 0x12)
- Tilt EXECUTE_REQUEST, status parsing (14-byte and 16-byte PRIVATE_RESPONSE formats), periodic tilt-aware status queries
- MQTT/HA integration: discovery with tilt topics, status publishing, command handling
- Fix status-handling bugs: D2 marker misinterpreted as target position, tilt not propagated to MQTT layer
- Console command `io_tilt`
- Protocol documentation in `doc/tilted_cover.md`

Closes #7