### PR TITLE
Add option to ignore auto-update flag and use device timer

### DIFF
--- a/config/IoHomeConfig.cpp
+++ b/config/IoHomeConfig.cpp
@@ -9,6 +9,7 @@ static const std::string IOHOME_CONFIG_PASSIVE_ENABLE = "passive_enabled"; // Ke
 static const std::string IOHOME_CONFIG_SYSTEM_KEY = "system_key";          // Key to store IO System key (string representation of 16 bytes)
 static const std::string IOHOME_CONFIG_NODE_ID = "node_id";                // Key to store our own node ID (string representation of 3 bytes)
 static const std::string IOHOME_CONFIG_TX_POWER = "tx_power";              // Key to store Tx power (uint8_t)
+static const std::string IOHOME_CONFIG_IGNORE_AUTO_UPDATE = "ign_autoupd"; // Key to store ignore auto-update flag (uint8_t)
 
 using namespace Helpers;
 
@@ -21,6 +22,7 @@ namespace Config
         NvsHelpers::DeleteValue(IOHOME_CONFIG_NAMESPACE, IOHOME_CONFIG_SYSTEM_KEY);
         NvsHelpers::DeleteValue(IOHOME_CONFIG_NAMESPACE, IOHOME_CONFIG_NODE_ID);
         NvsHelpers::DeleteValue(IOHOME_CONFIG_NAMESPACE, IOHOME_CONFIG_TX_POWER);
+        NvsHelpers::DeleteValue(IOHOME_CONFIG_NAMESPACE, IOHOME_CONFIG_IGNORE_AUTO_UPDATE);
     }
     bool IoHomeConfig::isLoggingEnabled()
     {
@@ -73,6 +75,21 @@ namespace Config
     {
         if (ioNodeId.length() != 6) return ESP_ERR_INVALID_ARG;
         return NvsHelpers::SetString(IOHOME_CONFIG_NAMESPACE, IOHOME_CONFIG_NODE_ID, ioNodeId);
+    }
+    bool IoHomeConfig::isIgnoreAutoUpdateEnabled()
+    {
+#ifdef CONFIG_IOHOMECONTROL_IGNORE_AUTO_UPDATE
+        uint8_t is_enabled = true;
+#else
+        uint8_t is_enabled = false;
+#endif
+        NvsHelpers::GetValue(IOHOME_CONFIG_NAMESPACE, IOHOME_CONFIG_IGNORE_AUTO_UPDATE, is_enabled);
+        return is_enabled;
+    }
+    esp_err_t IoHomeConfig::SetIgnoreAutoUpdate(bool ignoreAutoUpdate)
+    {
+        uint8_t is_enabled = ignoreAutoUpdate ? 0x01 : 0x00;
+        return NvsHelpers::SetValue(IOHOME_CONFIG_NAMESPACE, IOHOME_CONFIG_IGNORE_AUTO_UPDATE, is_enabled);
     }
     uint8_t IoHomeConfig::GetTxPower()
     {

--- a/config/IoHomeConfig.hpp
+++ b/config/IoHomeConfig.hpp
@@ -48,6 +48,15 @@ namespace Config
         /// @return ESP_OK if configuration put to storage without error
         static esp_err_t SetIoNodeId(const std::string &ioNodeId);
 
+        /// @brief Get ignore auto-update flag from configuration storage
+        /// @return true if auto-update (0x80) flag should be ignored and timer value used instead
+        static bool isIgnoreAutoUpdateEnabled();
+
+        /// @brief Set ignore auto-update flag to configuration storage
+        /// @param ignoreAutoUpdate true to ignore auto-update flag and use timer value
+        /// @return ESP_OK if configuration put to storage without error
+        static esp_err_t SetIgnoreAutoUpdate(bool ignoreAutoUpdate);
+
         /// @brief Get TX Power from configuration storage
         /// @return TX Power (dBm)
         static uint8_t GetTxPower();

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -53,6 +53,7 @@ If you choose Ethernet connectivity in the main parameters, this section permits
 This section permits to configure:
 - Enable logging in IO-HomeControl layer (all logs from the IO-HomeControl layer will be sent to command line interface, and MQTT log topic if MQTT is configured)
 - Passive mode only (ESP32 is not allowed to emit)
+- Ignore auto-update flag: when enabled, the estimated time from device responses is used to schedule status polls instead of trusting the device to send a proactive update. Useful when the device sends its auto-update to a different controller address.
 - IO System key, choose an unique value for your site
 - IO Node ID, choose unique value for your ESP32 to identify itself when sending commands to IO devices
 - TX Power (dBm), choose a value high enough to control your devices. A bigger value means more people around you could listen what you do...

--- a/helpers/CmdLineIoTools.cpp
+++ b/helpers/CmdLineIoTools.cpp
@@ -608,6 +608,7 @@ static struct
     struct arg_str *io_system_key;
     struct arg_str *node_id;
     struct arg_int *tx_power;
+    struct arg_int *ignore_auto_update;
     struct arg_end *end;
 } ioconfig_args;
 
@@ -627,6 +628,7 @@ static int do_ioconfig_cmd(int argc, char **argv)
         ESP_LOGI(TAG, "System key: %s", IoHomeConfig::GetIoSystemKey().c_str());
         ESP_LOGI(TAG, "Our node ID: %s", IoHomeConfig::GetIoNodeId().c_str());
         ESP_LOGI(TAG, "Tx power: %d", IoHomeConfig::GetTxPower());
+        ESP_LOGI(TAG, "Ignore auto-update: %s", IoHomeConfig::isIgnoreAutoUpdateEnabled() ? "enabled" : "disabled");
     }
     else if (ioconfig_args.del->count > 0)
     {
@@ -718,6 +720,18 @@ static int do_ioconfig_cmd(int argc, char **argv)
                 }
             }
         }
+        if (ioconfig_args.ignore_auto_update->count > 0)
+        {
+            err = IoHomeConfig::SetIgnoreAutoUpdate(ioconfig_args.ignore_auto_update->ival[0] != 0);
+            if (err != ESP_OK)
+            {
+                ESP_LOGE(TAG, "Failed to set ignore auto-update to configuration storage! (%d)", err);
+            }
+            else
+            {
+                ESP_LOGI(TAG, "Ignore auto-update set to configuration storage: %s", IoHomeConfig::isIgnoreAutoUpdateEnabled() ? "enabled" : "disabled");
+            }
+        }
         ESP_LOGI(TAG, "New configuration will be applied after reboot!");
     }
     return 0;
@@ -732,7 +746,8 @@ void register_ioconfig(void)
     ioconfig_args.io_system_key = arg_str0(NULL, "key", "<system key>", "IO System key (string representation of 16 bytes)");
     ioconfig_args.node_id = arg_str0(NULL, "id", "<node ID>", "Board Node ID (string representation of 3 bytes, eg 112233)");
     ioconfig_args.tx_power = arg_int0(NULL, "power", "<power>", "Tx power (range 0-20)");
-    ioconfig_args.end = arg_end(7);
+    ioconfig_args.ignore_auto_update = arg_int0(NULL, "ignoreautoupdate", "<state>", "1 to ignore auto-update flag and use timer value, 0 to trust auto-update");
+    ioconfig_args.end = arg_end(8);
 
     const esp_console_cmd_t ioconfig_cmd = {
         .command = "io_config",

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -13,6 +13,7 @@
 
 #include <stdio.h>
 #include <time.h>
+#include <algorithm>
 #include "esp_log.h"
 #include <ios>
 #include <sstream>
@@ -1620,7 +1621,7 @@ namespace iohome
             if (statusFrame.data[7] != 0xFF && statusFrame.data[7] != 0x00)
             {
               // We have an estimate in seconds
-              deviceIt->second.next_status_update_timestamp = esp_timer_get_time() + statusFrame.data[7] * 1000000 + STATUS_UPDATE_MANUAL_MARGIN_US;
+              deviceIt->second.next_status_update_timestamp = esp_timer_get_time() + std::max(static_cast<int64_t>(statusFrame.data[7]) * 1000000, STATUS_UPDATE_MANUAL_MARGIN_US);
             }
             else
               deviceIt->second.next_status_update_timestamp = esp_timer_get_time() + STATUS_UPDATE_AUTO_MARGIN_US;
@@ -1684,7 +1685,7 @@ namespace iohome
             if (statusFrame.data[10] != 0xFF && statusFrame.data[10] != 0x00)
             {
               // We have an estimate in seconds
-              deviceIt->second.next_status_update_timestamp = esp_timer_get_time() + statusFrame.data[10] * 1000000 + STATUS_UPDATE_MANUAL_MARGIN_US;
+              deviceIt->second.next_status_update_timestamp = esp_timer_get_time() + std::max(static_cast<int64_t>(statusFrame.data[10]) * 1000000, STATUS_UPDATE_MANUAL_MARGIN_US);
             }
             else
               deviceIt->second.next_status_update_timestamp = esp_timer_get_time() + STATUS_UPDATE_AUTO_MARGIN_US;

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -348,7 +348,8 @@ namespace iohome
       : mRadio(radio),
         mInitialized(false),
         mReceiving(false),
-        mVerbose(true)
+        mVerbose(true),
+        mIgnoreAutoUpdate(false)
   {
     memset(mOwnNodeId, 0, NODE_ID_SIZE);
     memset(mSystemKey, 0, AES_KEY_SIZE);
@@ -1609,11 +1610,11 @@ namespace iohome
         else
         {
           // Currently moving, try to guess when we should have next status update
-          if (statusFrame.data[1] & CMD_PARAM_STATUS_EXPECTED)
+          if ((statusFrame.data[1] & CMD_PARAM_STATUS_EXPECTED) && !mIgnoreAutoUpdate)
             deviceIt->second.next_status_update_timestamp = esp_timer_get_time() + STATUS_UPDATE_AUTO_MARGIN_US;
           else
           {
-            // We will not receive new status automatically, so let's see if device provides an estimated time
+            // We will not receive new status automatically (or ignoring auto-update), so let's see if device provides an estimated time
             if (statusFrame.data[7] != 0xFF && statusFrame.data[7] != 0x00)
             {
               // We have an estimate in seconds
@@ -1673,11 +1674,11 @@ namespace iohome
         else
         {
           // Currently moving, try to guess when we should have next status update
-          if (statusFrame.data[1] & CMD_PARAM_STATUS_EXPECTED)
+          if ((statusFrame.data[1] & CMD_PARAM_STATUS_EXPECTED) && !mIgnoreAutoUpdate)
             deviceIt->second.next_status_update_timestamp = esp_timer_get_time() + STATUS_UPDATE_AUTO_MARGIN_US;
           else
           {
-            // We will not receive new status automatically, so let's see if device provides an estimated time
+            // We will not receive new status automatically (or ignoring auto-update), so let's see if device provides an estimated time
             if (statusFrame.data[10] != 0xFF && statusFrame.data[10] != 0x00)
             {
               // We have an estimate in seconds

--- a/io-homecontrol/IoHomeControl.hpp
+++ b/io-homecontrol/IoHomeControl.hpp
@@ -73,6 +73,15 @@ namespace iohome
     /// @return true if verbose logging enabled
     bool isVerbose() { return mVerbose; }
 
+    /// @brief Set ignore auto-update flag. When enabled, the timer value from device response is used
+    ///        instead of trusting the device to send a proactive status update (0x71).
+    /// @param enable true to ignore auto-update flag and use timer, false to trust auto-update
+    void SetIgnoreAutoUpdate(bool enable) { mIgnoreAutoUpdate = enable; }
+
+    /// @brief Get ignore auto-update flag
+    /// @return true if auto-update flag is ignored
+    bool isIgnoreAutoUpdate() { return mIgnoreAutoUpdate; }
+
     /// @brief Get active/passive mode. Was set by calling Begin().
     /// @return true if active, false if passive (no radio transmission, only listening)
     bool isPassive() { return mPassiveMode; }
@@ -201,6 +210,7 @@ namespace iohome
     bool mReceiving;   // true if StartReceive has been called (and no call to StopReceive!)
     bool mVerbose;     // true if verbose mode (logs are sent to registered callback)
     bool mPassiveMode; // true if passive mode (will not send frames to radio, only listening)
+    bool mIgnoreAutoUpdate; // true to ignore auto-update flag (0x80) and use timer value instead
 
     /// @brief Transmit a frame
     /// @param frame IoFrame to transmit

--- a/main/IoRtsManager.cpp
+++ b/main/IoRtsManager.cpp
@@ -244,6 +244,7 @@ namespace IoRts
             if (mIoHome != nullptr)
             {
                 mIoHome->SetVerbose(IoHomeConfig::isLoggingEnabled());
+                mIoHome->SetIgnoreAutoUpdate(IoHomeConfig::isIgnoreAutoUpdateEnabled());
                 mIoHome->Begin(IoHomeConfig::GetIoNodeId(), IoHomeConfig::GetIoSystemKey(), IoHomeConfig::isPassiveModeEnabled());
                 mIoHome->ConfigureRadio(IoHomeConfig::GetTxPower());
             }

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -196,6 +196,15 @@ menu "IO RTS Project Configuration"
             bool "Passive only (not allowed to emit)"
             default y
 
+        config IOHOMECONTROL_IGNORE_AUTO_UPDATE
+            bool "Ignore auto-update flag and use timer value"
+            default n
+            help
+                When enabled, the device response flag indicating a proactive status update (0x71) will be
+                ignored. Instead, the estimated time provided by the device is used to schedule the next
+                status poll. Enable this if your devices report the auto-update flag but you never receive
+                the proactive update (e.g. because the device sends it to a different controller address).
+
         config IOHOMECONTROL_DEFAULT_KEY
             string "IO System key (16 bytes)"
             default "00112233445566778899AABBCCDDEEFF"


### PR DESCRIPTION
## Summary

- Adds configurable option to ignore the device auto-update flag (0x80) in status responses and use the device-provided timer estimate for scheduling the next status poll instead
- Devices may promise a proactive 0x71 status update but send it to a different controller address, causing a 60s wait with no update — this option works around that
- Configurable via menuconfig (`IO Configuration` menu) and runtime CLI (`io_config --ignoreautoupdate 1`)
- Changed status poll delay from `timer + 1s` to `max(timer, 1s)` to avoid unnecessary extra delay while keeping a 1s minimum