### PR TITLE
Fix false 'moving' state when device has reached target position

### DIFF
--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -1582,7 +1582,7 @@ namespace iohome
               deviceIt->second.position = UNKNOWN_POSITION;
           }
         }
-        if (deviceIt->second.is_stopped && tmpTargetPos <= CMD_PARAM_STATUS_POS_MAX && tmpCurrentPos <= CMD_PARAM_STATUS_POS_MAX && tmpTargetPos != tmpCurrentPos)
+        if (deviceIt->second.is_stopped && !hasReachedTargetPosition(tmpTargetPos, tmpCurrentPos))
           deviceIt->second.is_stopped = false; // some devices set 'stopped' flag when moving, force it to update status!
 
         // Extract tilt value from 16-byte tilt-extended response only (from 03200100 query)

--- a/io-homecontrol/protocol/iohome_constants.h
+++ b/io-homecontrol/protocol/iohome_constants.h
@@ -155,6 +155,7 @@ namespace iohome
   constexpr uint8_t CMD_PARAM_STATUS_STOPPED = 0x01;    // In CMD_PRIVATE_RESPONSE and CMD_STATUS_UPDATE, byte0 & 0x01 mens device is not moving
   constexpr uint8_t CMD_PARAM_STATUS_EXPECTED = 0x80;   // In CMD_PRIVATE_RESPONSE and CMD_STATUS_UPDATE, byte1 & 0x80 mens device should send CMD_STATUS_UPDATE
   constexpr uint16_t CMD_PARAM_STATUS_POS_MAX = 0xC800; // 100% closed
+  constexpr uint16_t CMD_PARAM_STATUS_POS_TOLERANCE = 100; // ~0.2% tolerance for position comparison (51200 = 100%)
 
   constexpr uint8_t CMD_PARAM_ERROR_BAD_AUTH = 0x18;
 

--- a/io-homecontrol/protocol/iohome_device.cpp
+++ b/io-homecontrol/protocol/iohome_device.cpp
@@ -15,6 +15,14 @@ namespace iohome
             return false;
         }
     }
+
+    bool hasReachedTargetPosition(uint16_t targetPos, uint16_t currentPos)
+    {
+        if (targetPos > CMD_PARAM_STATUS_POS_MAX || currentPos > CMD_PARAM_STATUS_POS_MAX)
+            return false;
+        uint16_t diff = (targetPos > currentPos) ? (targetPos - currentPos) : (currentPos - targetPos);
+        return diff <= CMD_PARAM_STATUS_POS_TOLERANCE;
+    }
     std::string IoDeviceManufacturer(Manufacturer mf)
     {
         switch (mf)

--- a/io-homecontrol/protocol/iohome_device.hpp
+++ b/io-homecontrol/protocol/iohome_device.hpp
@@ -41,6 +41,12 @@ namespace iohome
     /// @return true if the device type supports tilt
     bool deviceTypeSupportsTilt(DeviceType type);
 
+    /// @brief Check if target and current positions are close enough to consider the device as having reached its target
+    /// @param targetPos Target position (raw value, 0 to CMD_PARAM_STATUS_POS_MAX)
+    /// @param currentPos Current position (raw value, 0 to CMD_PARAM_STATUS_POS_MAX)
+    /// @return true if both positions are valid and within tolerance
+    bool hasReachedTargetPosition(uint16_t targetPos, uint16_t currentPos);
+
     std::string IoDeviceManufacturer(Manufacturer mf);
     
 } // namespace iohome


### PR DESCRIPTION
## Problem

When a device reaches its target position, it reports `stopped` in byte 0 of CMD_PRIVATE_RESPONSE (0x04). However, the current position often differs from target by a tiny amount (e.g. target `0x3C00` vs current `0x3C2E` — a 46-unit / ~0.09% difference). The existing strict `!=` check overrides the device's stopped flag, incorrectly reporting the device as still moving. This triggers unnecessary status polling cycles.

## Fix

- Add `hasReachedTargetPosition()` helper that compares target and current positions with a configurable tolerance (`CMD_PARAM_STATUS_POS_TOLERANCE = 100`, ~0.2% of the full 0xC800 range).
- Replace the strict inequality check in the `CMD_PRIVATE_RESPONSE` handler with the new helper.

Tested on a Somfy RS100 IO roller shutter — confirmed the device correctly reports `Moving: No` when it settles within tolerance of the target.