### PR TITLE
Add identify command for IO-Homecontrol devices

### DIFF
--- a/helpers/CmdLineIoTools.cpp
+++ b/helpers/CmdLineIoTools.cpp
@@ -519,6 +519,44 @@ void register_iodevicefeedback(void)
     ESP_ERROR_CHECK(esp_console_cmd_register(&iodevicefeedback_cmd));
 }
 
+// ******************* IO IDENTIFY DEVICE ********************
+
+/// @brief Structure used by the 'io_identify' command
+static struct
+{
+    struct arg_str *device_id;
+    struct arg_end *end;
+} ioidentify_args;
+
+static int do_ioidentify_cmd(int argc, char **argv)
+{
+    int nerrors = arg_parse(argc, argv, (void **)&ioidentify_args);
+    if (nerrors != 0)
+    {
+        arg_print_errors(stderr, ioidentify_args.end, argv[0]);
+        return 1;
+    }
+    sIoHome->IdentifyDevice(ioidentify_args.device_id->sval[0]);
+    return 0;
+}
+
+void register_ioidentify(void)
+{
+    ioidentify_args.device_id = arg_str1(NULL, NULL, "<deviceid>", "ID of the device, 3 bytes (eg 112233)");
+    ioidentify_args.end = arg_end(1);
+
+    const esp_console_cmd_t ioidentify_cmd = {
+        .command = "io_identify",
+        .help = "Identify an IO-HomeControl device (device will physically identify itself, e.g., brief jog movement)",
+        .hint = NULL,
+        .func = &do_ioidentify_cmd,
+        .argtable = &ioidentify_args,
+        .func_w_context = NULL,
+        .context = NULL};
+
+    ESP_ERROR_CHECK(esp_console_cmd_register(&ioidentify_cmd));
+}
+
 // ******************* IO INVERT DEVICE ********************
 
 /// @brief Structure used by the 'io_invertdevice' command
@@ -857,6 +895,7 @@ void register_io_cmdline_tools(IoRts::IoRtsManager *io_rts_manager)
     register_iolinkremote();
     register_ioremoveremote();
     register_iodevicefeedback();
+    register_ioidentify();
     register_ioinvertdevice();
     register_iosendraw();
     register_iolistdevices();

--- a/helpers/MqttHelpers.cpp
+++ b/helpers/MqttHelpers.cpp
@@ -39,8 +39,9 @@ static const std::string MQTT_CLIENT_LINK_REMOTE_ID = "LinkIoRemote";        // 
 static const std::string MQTT_CLIENT_REM_REMOTE_ID = "RemoveIoRemote";       // unique id and action for "RemoveRemote" component
 static const std::string MQTT_CLIENT_SET_DEVICE_NAME_ID = "SetIoDeviceName"; // unique id and action for "SetDeviceName" component
 
-static const std::string MQTT_CLIENT_PREFIX_IO = "io_";      // unique_id prefix for IO devices
-static const std::string MQTT_CLIENT_SUFFIX_FAV_IO = "_fav"; // unique_id suffix for IO devices "favorite" button
+static const std::string MQTT_CLIENT_PREFIX_IO = "io_";          // unique_id prefix for IO devices
+static const std::string MQTT_CLIENT_SUFFIX_FAV_IO = "_fav";    // unique_id suffix for IO devices "favorite" button
+static const std::string MQTT_CLIENT_SUFFIX_IDENTIFY = "_ident"; // unique_id suffix for IO devices "identify" button
 
 static const std::string MQTT_CLIENT_BIRTH_WILL_TOPIC = "/status"; // birth and last will topic
 static const std::string MQTT_CLIENT_BIRTH_MSG = "online";         // last will message - birth
@@ -338,6 +339,10 @@ namespace Helpers
                                 else if (command.compare("UNLOCK") == 0)
                                 {
                                     mqttHelper->GetIoRtsManager()->mIoHome->SetDevicePosition(deviceID, SWITCH_LIGHT_ON_POSITION); // not sure, wait for feedback
+                                }
+                                else if (command.compare("IDENTIFY") == 0)
+                                {
+                                    mqttHelper->GetIoRtsManager()->mIoHome->IdentifyDevice(deviceID);
                                 }
                             }
                             else if (topic_str.ends_with(MQTT_CLIENT_COMMAND_POSITION_TOPIC)) // it should be a position between 0 and 100
@@ -934,6 +939,27 @@ namespace Helpers
                     error = error || (cJSON_AddStringToObject(cmp, "name", it->second.info.name) == NULL);              // name
                     error = error || (cJSON_AddStringToObject(cmp, "command_topic", device_cmd_topic.c_str()) == NULL); // command_topic
                     error = error || (cJSON_AddStringToObject(cmp, "state_topic", device_state_topic.c_str()) == NULL); // state_topic
+                }
+
+                // add "identify" button as a separate component for all device types
+                if (!error)
+                {
+                    std::string device_id_ident = MQTT_CLIENT_PREFIX_IO + it->first + MQTT_CLIENT_SUFFIX_IDENTIFY;
+                    std::string device_cmd_topic = GetTopicPrefix() + "/" + device_id + MQTT_CLIENT_COMMAND_TOPIC;
+                    cJSON *ident = cJSON_AddObjectToObject(cmps, device_id_ident.c_str());
+                    if (ident == NULL)
+                        error = true;
+                    else
+                    {
+                        error = error || (cJSON_AddStringToObject(ident, "p", "button") == NULL);                        // platform
+                        error = error || (cJSON_AddStringToObject(ident, "unique_id", device_id_ident.c_str()) == NULL); // unique_id
+                        std::string identName = it->second.info.name + std::string(" Identify");
+                        error = error || (cJSON_AddStringToObject(ident, "name", identName.c_str()) == NULL);                   // name
+                        error = error || (cJSON_AddStringToObject(ident, "command_topic", device_cmd_topic.c_str()) == NULL);    // command_topic — uses /set
+                        error = error || (cJSON_AddStringToObject(ident, "payload_press", "IDENTIFY") == NULL);                 // payload_press
+                        error = error || (cJSON_AddStringToObject(ident, "device_class", "identify") == NULL);                  // device_class
+                        error = error || (cJSON_AddStringToObject(ident, "entity_category", "diagnostic") == NULL);             // entity_category
+                    }
                 }
             }
 

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -1254,6 +1254,50 @@ namespace iohome
     }
   }
 
+  bool IoHomeControl::IdentifyDevice(const std::string &deviceID)
+  {
+    if (!mInitialized || !mReceiving || mPassiveMode)
+    {
+      IO_LOGE("IdentifyDevice: invalid state! (not initialized or not listening or passive mode)");
+      return false;
+    }
+    std::map<std::string, IoDevice>::iterator it = sDeviceMap.find(deviceID);
+    if (it == sDeviceMap.end())
+    {
+      IO_LOGE("IdentifyDevice: no device found in list!");
+      return false;
+    }
+    else if (it->second.is_deleted)
+    {
+      IO_LOGE("IdentifyDevice: device is marked as deleted, add it before using it!");
+      return false;
+    }
+    if (xSemaphoreTake(sMutex, MUTEX_MAX_WAIT_TICKS))
+    {
+      IoFrame request;
+      IoFrame response;
+      bool ret = false;
+      UBaseType_t currentPriority = uxTaskPriorityGet(NULL);
+      vTaskPrioritySet(NULL, IO_FRAME_PROCESSING_TASK); // change task priority to higher!
+      if (create_identify_request(request, mOwnNodeId, it->second.info.node_id) && SendAndReceive(request, response, FREQUENCY_CHANNEL_2))
+      {
+        ret = true; // command sent and response received (response may be CMD_ERROR_RESPONSE which is expected for identify)
+      }
+      else
+      {
+        IO_LOGE("IdentifyDevice: failed to send request or didn't receive a response!");
+      }
+      vTaskPrioritySet(NULL, currentPriority); // restore task priority
+      xSemaphoreGive(sMutex);
+      return ret;
+    }
+    else
+    {
+      IO_LOGE("IdentifyDevice: failed to take mutex!");
+      return false;
+    }
+  }
+
   void IoHomeControl::InvertOpenClosePositionForDevice(const std::string &deviceID)
   {
     if (!mInitialized || !mReceiving || mPassiveMode)

--- a/io-homecontrol/IoHomeControl.hpp
+++ b/io-homecontrol/IoHomeControl.hpp
@@ -202,6 +202,11 @@ namespace iohome
     /// @return true if no error
     bool SendRaw(const std::string &rawFrame, uint32_t frequency);
 
+    /// @brief Identify a device — makes it physically identify itself (e.g., brief jog movement)
+    /// @param deviceID Device ID (6 characters as hex representation of the 3 bytes, eg "112233")
+    /// @return true on success, false on error
+    bool IdentifyDevice(const std::string &deviceID);
+
   protected:
     uint8_t mOwnNodeId[NODE_ID_SIZE]; // Our NodeID (3 bytes)
     uint8_t mSystemKey[AES_KEY_SIZE]; // Our system key (16 bytes)

--- a/io-homecontrol/protocol/iohome_commands.cpp
+++ b/io-homecontrol/protocol/iohome_commands.cpp
@@ -9,6 +9,21 @@
 
 namespace iohome
 {
+    bool create_identify_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id)
+    {
+        // Initialize frame for 2W, start of exchange
+        init_frame(frame, true, true, false, false);
+
+        // Set source and destination
+        set_destination(frame, dst_node_id);
+        set_source(frame, own_node_id);
+
+        // Set data: 0x01 = Command Originator (User), 0xFF = identify parameter
+        uint8_t data[2] = {0x01, 0xFF};
+
+        return set_command(frame, CMD_IDENTIFY, data, sizeof(data));
+    }
+
     bool create_execute_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id, bool is_low_power, uint8_t position, bool quiet)
     {
         // Initialize frame

--- a/io-homecontrol/protocol/iohome_commands.hpp
+++ b/io-homecontrol/protocol/iohome_commands.hpp
@@ -8,6 +8,13 @@
 
 namespace iohome
 {
+    /// @brief Create an identify IO Frame (0x1E) — makes the device physically identify itself (e.g., brief jog movement)
+    /// @param frame Output IoFrame structure
+    /// @param own_node_id Source node ID (3 bytes)
+    /// @param dst_node_id Destination node ID (3 bytes) for output frame to create
+    /// @return true on success
+    bool create_identify_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id);
+
     /// @brief Create an execute IO Frame (0x00)
     /// @param frame Output IoFrame structure
     /// @param own_node_id Source node ID (3 bytes)

--- a/io-homecontrol/protocol/iohome_constants.h
+++ b/io-homecontrol/protocol/iohome_constants.h
@@ -94,6 +94,9 @@ namespace iohome
   constexpr uint8_t CMD_PRIVATE2 = 0x0C;          // No authentication needed
   constexpr uint8_t CMD_PRIVATE2_RESPONSE = 0x0D; // Response to 0x0C
 
+  // Identify command
+  constexpr uint8_t CMD_IDENTIFY = 0x1E; // Authentication needed — makes the device physically identify itself (e.g., brief jog movement)
+
   // Discovery Commands
   constexpr uint8_t CMD_DISCOVER_REQUEST = 0x28;          // No authentication needed, broadcast to 0x00003b
   constexpr uint8_t CMD_DISCOVER_RESPONSE = 0x29;         // Response to 0x28 and 0x2E


### PR DESCRIPTION
## Summary
- Adds command 0x1E (identify) that makes a device physically identify itself (e.g., brief jog movement)
- Console: `io_identify <deviceid>`
- MQTT: publish `IDENTIFY` to the device `/set` topic
- Home Assistant: diagnostic "Identify" button per device