### PR TITLE
fix SendRaw missing task priority elevation for battery-powered devices

### DIFF
--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -1337,12 +1337,16 @@ namespace iohome
     }
     uint8_t buffer[FRAME_MAX_SIZE];
     HexStringToBuff(rawFrame, buffer, FRAME_MAX_SIZE);
+    uint8_t actualLen = rawFrame.length() / 2;
+    buffer[0] = (buffer[0] & ~CTRL0_LENGTH_MASK) | ((actualLen - 1) & CTRL0_LENGTH_MASK);
     IoFrame request;
-    if (parse_frame(buffer, rawFrame.length() / 2, request))
+    if (parse_frame(buffer, actualLen, request))
     {
       if (xSemaphoreTake(sMutex, MUTEX_MAX_WAIT_TICKS))
       {
         bool ret = false;
+        UBaseType_t currentPriority = uxTaskPriorityGet(NULL);
+        vTaskPrioritySet(NULL, IO_FRAME_PROCESSING_TASK);
         if (is_end(request))
         {
           ret = TransmitFrame(request, frequency, is_start(request) ? LONG_PREAMBLE_LENGTH : SHORT_PREAMBLE_LENGTH);
@@ -1352,6 +1356,7 @@ namespace iohome
           IoFrame response;
           ret = SendAndReceive(request, response, frequency);
         }
+        vTaskPrioritySet(NULL, currentPriority);
         xSemaphoreGive(sMutex);
         return ret;
       }


### PR DESCRIPTION
## Problem

`SendRaw` was the only command method that called `SendAndReceive` without
first elevating the FreeRTOS task priority to `IO_FRAME_PROCESSING_TASK`.
Every other method (`SetDevicePosition`, `IdentifyDevice`, `GetStatus`, etc.)
follows the pattern:

    UBaseType_t currentPriority = uxTaskPriorityGet(NULL);
    vTaskPrioritySet(NULL, IO_FRAME_PROCESSING_TASK);
    // ... SendAndReceive ...
    vTaskPrioritySet(NULL, currentPriority);

Without the priority elevation the transmit queue is not serviced quickly
enough. Battery-powered (solar) devices have a very short response window
after authentication — the device wakes, challenges, and goes back to sleep
within ~500 ms. The missing priority caused the host to miss the final
CMD 0x04, making every io_sendraw call to a battery device fail with
"SendAndReceive: didn't receive final response!".

## Fix

- Add vTaskPrioritySet elevation/restore around SendAndReceive in SendRaw,
  matching the pattern used by all other command methods.
- Correct the CTRL0 length field from the actual buffer size before parsing,
  so callers do not have to manually encode (frame_size - 1) in bits[4:0].

## Tested on

Somfy RS100 IO solar roller shutters (battery-powered, 2W) — io_sendraw
commands now complete the full auth handshake and receive CMD 0x04 responses
reliably. Mains-powered devices unaffected.
