### PR TITLE
add io_getbattery command to query battery-status and battery-state

### DIFF
--- a/helpers/CmdLineIoTools.cpp
+++ b/helpers/CmdLineIoTools.cpp
@@ -635,6 +635,43 @@ void register_iosendraw(void)
     ESP_ERROR_CHECK(esp_console_cmd_register(&iosendraw_cmd));
 }
 
+// ******************* IO GET BATTERY ********************
+
+static struct
+{
+    struct arg_str *device_id;
+    struct arg_end *end;
+} iogetbattery_args;
+
+static int do_iogetbattery_cmd(int argc, char **argv)
+{
+    int nerrors = arg_parse(argc, argv, (void **)&iogetbattery_args);
+    if (nerrors != 0)
+    {
+        arg_print_errors(stderr, iogetbattery_args.end, argv[0]);
+        return 1;
+    }
+    sIoHome->DeviceGetBattery(iogetbattery_args.device_id->sval[0]);
+    return 0;
+}
+
+void register_iogetbattery(void)
+{
+    iogetbattery_args.device_id = arg_str1(NULL, NULL, "<deviceid>", "ID of the device, 3 bytes (eg 112233)");
+    iogetbattery_args.end = arg_end(1);
+
+    const esp_console_cmd_t cmd = {
+        .command = "io_getbattery",
+        .help = "Query battery-status (0x06) and battery-state (0x09) of an IO-HomeControl device",
+        .hint = NULL,
+        .func = &do_iogetbattery_cmd,
+        .argtable = &iogetbattery_args,
+        .func_w_context = NULL,
+        .context = NULL};
+
+    ESP_ERROR_CHECK(esp_console_cmd_register(&cmd));
+}
+
 // ******************* IO LIST DEVICES ********************
 static int do_iolistdevices_cmd(int argc, char **argv)
 {
@@ -898,6 +935,7 @@ void register_io_cmdline_tools(IoRts::IoRtsManager *io_rts_manager)
     register_ioidentify();
     register_ioinvertdevice();
     register_iosendraw();
+    register_iogetbattery();
     register_iolistdevices();
     register_ioconfig();
     register_iotilt();

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -1827,4 +1827,55 @@ namespace iohome
     }
   }
 
+  bool IoHomeControl::DeviceGetBattery(const std::string &deviceID)
+  {
+    if (!mInitialized || !mReceiving || mPassiveMode)
+    {
+      IO_LOGE("DeviceGetBattery: invalid state! (not initialized or not listening or passive mode)");
+      return false;
+    }
+    uint8_t tmpDeviceId[NODE_ID_SIZE];
+    HexStringToBuff(deviceID, tmpDeviceId, NODE_ID_SIZE);
+    if (xSemaphoreTake(sMutex, MUTEX_MAX_WAIT_TICKS))
+    {
+      IoFrame request, response;
+      bool status_ok = false, state_ok = false;
+      uint16_t battery_status = 0, battery_state = 0;
+      bool is_battery_powered = false;
+      UBaseType_t currentPriority = uxTaskPriorityGet(NULL);
+      vTaskPrioritySet(NULL, IO_FRAME_PROCESSING_TASK);
+
+      if (create_getbattery_request(request, mOwnNodeId, tmpDeviceId, 0x06)
+          && SendAndReceive(request, response, FREQUENCY_CHANNEL_2)
+          && response.command_id == CMD_PRIVATE_RESPONSE && response.data_len >= 4)
+      {
+        is_battery_powered = (response.data[1] == 0x60);
+        battery_status = (uint16_t)(response.data[2] << 8) | response.data[3];
+        status_ok = true;
+      }
+
+      if (create_getbattery_request(request, mOwnNodeId, tmpDeviceId, 0x09)
+          && SendAndReceive(request, response, FREQUENCY_CHANNEL_2)
+          && response.command_id == CMD_PRIVATE_RESPONSE && response.data_len >= 4)
+      {
+        battery_state = (uint16_t)(response.data[2] << 8) | response.data[3];
+        state_ok = true;
+      }
+
+      vTaskPrioritySet(NULL, currentPriority);
+      xSemaphoreGive(sMutex);
+
+      if (status_ok || state_ok)
+        IO_LOGI("Battery {}: powered={}, status=0x{:04X}, state=0x{:04X}",
+                deviceID, is_battery_powered ? "battery/solar" : "mains",
+                battery_status, battery_state);
+      else
+        IO_LOGE("DeviceGetBattery {}: no response", deviceID);
+
+      return status_ok || state_ok;
+    }
+    IO_LOGE("DeviceGetBattery: failed to take mutex!");
+    return false;
+  }
+
 } // namespace iohome

--- a/io-homecontrol/IoHomeControl.hpp
+++ b/io-homecontrol/IoHomeControl.hpp
@@ -207,6 +207,11 @@ namespace iohome
     /// @return true on success, false on error
     bool IdentifyDevice(const std::string &deviceID);
 
+    /// @brief Query battery-status (0x06) and battery-state (0x09) via CMD 0x03 and log the result
+    /// @param deviceID Device ID (6 characters as hex representation of the 3 bytes, eg "112233")
+    /// @return true if at least one query succeeded
+    bool DeviceGetBattery(const std::string &deviceID);
+
   protected:
     uint8_t mOwnNodeId[NODE_ID_SIZE]; // Our NodeID (3 bytes)
     uint8_t mSystemKey[AES_KEY_SIZE]; // Our system key (16 bytes)

--- a/io-homecontrol/protocol/iohome_commands.cpp
+++ b/io-homecontrol/protocol/iohome_commands.cpp
@@ -438,4 +438,13 @@ namespace iohome
         return set_command(frame, CMD_SET_CONFIG1, data, sizeof(data)); // device shall reply with command 0x70 and data 0x05 if OK, FE 08 if KO
     }
 
+    bool create_getbattery_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id, uint8_t function_id)
+    {
+        init_frame(frame, true, true, false, true);
+        set_destination(frame, dst_node_id);
+        set_source(frame, own_node_id);
+        uint8_t data[3] = {function_id, 0x00, 0x00};
+        return set_command(frame, CMD_PRIVATE, data, sizeof(data));
+    }
+
 } // namespace iohome

--- a/io-homecontrol/protocol/iohome_commands.hpp
+++ b/io-homecontrol/protocol/iohome_commands.hpp
@@ -171,6 +171,14 @@ namespace iohome
     /// @return true on success
     bool create_getinfo3_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id);
 
+    /// @brief Create a battery query IO Frame (0x03) for function IDs 0x06 (battery-status) or 0x09 (battery-state)
+    /// @param frame Output IoFrame structure
+    /// @param own_node_id Source node ID (3 bytes)
+    /// @param dst_node_id Destination node ID (3 bytes)
+    /// @param function_id Private function ID: 0x06 = battery-status, 0x09 = battery-state
+    /// @return true on success
+    bool create_getbattery_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id, uint8_t function_id);
+
     /// @brief Create a status update response IO Frame (0x72)
     /// @param frame Output IoFrame structure
     /// @param own_node_id Source node ID (3 bytes)


### PR DESCRIPTION
Adds a new `io_getbattery <deviceid>` CLI command that queries Private Function IDs 0x06 (battery-status) and 0x09 (battery-state) via CMD 0x03 and logs the result.

Tested on Somfy RS100 IO solar roller shutters and a mains-powered awning:
- Solar devices: powered=battery/solar, status=0x0000, state=0xD80A
- Mains device:  powered=mains,          status=0x0000, state=0xC800

data[1]=0x60 in the CMD 0x04 response identifies battery/solar devices; data[1]=0x00 identifies mains-powered devices.  state=0xD80A appears to indicate a healthy solar charge; state=0xC800 (CMD_PARAM_STATUS_POS_MAX) is returned by mains devices.

## Summary

Adds a new `io_getbattery <deviceid>` CLI command that queries Private
Function IDs 0x06 (battery-status) and 0x09 (battery-state) via CMD 0x03
(no authentication required) and logs the result.

New files/symbols:
- `create_getbattery_request()` in iohome_commands — builds a CMD 0x03
  frame with the given function ID
- `DeviceGetBattery()` in IoHomeControl — sends both queries, parses the
  6-byte CMD 0x04 responses, and logs a single summary line
- `io_getbattery` CLI command in CmdLineIoTools

## Output
I (xxx) io-hctrl: Battery 70D78E: powered=battery/solar, status=0x0000, state=0xD80A
I (xxx) io-hctrl: Battery BF14E4: powered=mains, status=0x0000, state=0xC800

## Response format (CMD 0x04, 6 bytes)

| Byte | Meaning |
|------|---------|
| 0 | Status (0x05 = OK) |
| 1 | 0x60 = battery/solar device, 0x00 = mains device |
| 2–3 | Value (uint16) |
| 4–5 | 0x0000 |

## Tested on

- Somfy RS100 IO solar roller shutters (battery/solar):
  status=0x0000, state=0xD80A (healthy solar charge)
- Somfy Sonesse 40 IO awning (mains):
  status=0x0000, state=0xC800 (mains = full supply)
