### PR TITLE
fix info/name requests failing silently on solar/battery-powered devices

### DIFF
--- a/io-homecontrol/protocol/iohome_commands.cpp
+++ b/io-homecontrol/protocol/iohome_commands.cpp
@@ -337,8 +337,8 @@ namespace iohome
 
     bool create_getname_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id)
     {
-        // Initialize frame
-        init_frame(frame, true, true, false, false);
+        // Initialize frame — LOW_POWER flag required for solar/battery devices to respond
+        init_frame(frame, true, true, false, true);
 
         // Set source and destination
         set_destination(frame, dst_node_id);
@@ -366,8 +366,8 @@ namespace iohome
 
     bool create_getinfo1_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id)
     {
-        // Initialize frame
-        init_frame(frame, true, true, false, false);
+        // Initialize frame — LOW_POWER flag required for solar/battery devices to respond
+        init_frame(frame, true, true, false, true);
 
         // Set source and destination
         set_destination(frame, dst_node_id);
@@ -378,8 +378,8 @@ namespace iohome
 
     bool create_getinfo2_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id)
     {
-        // Initialize frame
-        init_frame(frame, true, true, false, false);
+        // Initialize frame — LOW_POWER flag required for solar/battery devices to respond
+        init_frame(frame, true, true, false, true);
 
         // Set source and destination
         set_destination(frame, dst_node_id);
@@ -390,8 +390,8 @@ namespace iohome
 
     bool create_getinfo3_request(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id)
     {
-        // Initialize frame
-        init_frame(frame, true, true, false, false);
+        // Initialize frame — LOW_POWER flag required for solar/battery devices to respond
+        init_frame(frame, true, true, false, true);
 
         // Set source and destination
         set_destination(frame, dst_node_id);


### PR DESCRIPTION
Info and name query frames were built with is_low_power=false, producing CTRL1=0x03. Solar and battery-powered io-homecontrol devices require the LOW_POWER flag (CTRL1=0x20) to respond; without it they silently ignore the frame. This caused device names and info1/info2/info3 to never be populated for solar devices (shown as '?' in io_listdevices).

Confirmed by live testing with CTRL1=0x03 (no response) vs CTRL1=0x20 (full responses including name, serial, device type) on a Somfy OXIMO 40 SOLAR device. Hardwired devices (e.g. Horizontal Awning) already use CTRL1=0x20 for all other commands and respond correctly with this flag set.