### PR TITLE
 TaHoma key pull — IV fix, CMD 38 retry loop, CMD 29 format corrections

### DIFF
--- a/components/web_server/web_server.cpp
+++ b/components/web_server/web_server.cpp
@@ -2380,7 +2380,7 @@ void web_server_start(void *ioRtsManager)
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.stack_size = 8192;
     config.task_priority = tskIDLE_PRIORITY + 3; // below radio (8), IO processing (6), status updates (4)
-    config.max_uri_handlers = 48;
+    config.max_uri_handlers = 52;
     config.max_open_sockets = 13; // browser opens many parallel connections for static files + WS
     config.send_wait_timeout = 2;  // seconds; cap blocking sends to dead clients
     config.recv_wait_timeout = 2;

--- a/components/web_server/web_server.cpp
+++ b/components/web_server/web_server.cpp
@@ -2146,6 +2146,54 @@ static esp_err_t api_pair_device_status_get(httpd_req_t *req)
     return ESP_OK;
 }
 
+// ─── Send-key observation (step-by-step: respond to CMD 28 as controller, log response) ─
+
+static bool s_send_key_active = false;
+
+static void send_key_task(void *)
+{
+    ESP_LOGI(TAG, "Send-key observe task started");
+    if (!s_manager->mIoHome) {
+        s_send_key_active = false;
+        web_server_broadcast_message("{\"type\":\"send_key_done\"}");
+        vTaskDelete(nullptr);
+        return;
+    }
+    s_manager->mIoHome->WaitAndRespondToCmd28(&s_send_key_active);
+    s_send_key_active = false;
+    web_server_broadcast_message("{\"type\":\"send_key_done\"}");
+    vTaskDelete(nullptr);
+}
+
+static esp_err_t api_send_key_start_post(httpd_req_t *req)
+{
+    if (s_send_key_active) {
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_sendstr(req, "{\"status\":\"busy\"}");
+        return ESP_OK;
+    }
+    s_send_key_active = true;
+    xTaskCreate(send_key_task, "send_key_task", 4096, nullptr, 5, nullptr);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, "{\"status\":\"started\"}");
+    return ESP_OK;
+}
+
+static esp_err_t api_send_key_stop_post(httpd_req_t *req)
+{
+    s_send_key_active = false;
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, "{\"status\":\"stopped\"}");
+    return ESP_OK;
+}
+
+static esp_err_t api_send_key_status_get(httpd_req_t *req)
+{
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, s_send_key_active ? "{\"active\":true}" : "{\"active\":false}");
+    return ESP_OK;
+}
+
 // ─── Remote capture ─────────────────────────────────────────────────────────
 
 #define REMOTE_CAPTURE_TIMEOUT_MS 30000
@@ -2411,6 +2459,9 @@ void web_server_start(void *ioRtsManager)
     reg("/api/pair-device/start",        HTTP_POST, api_pair_device_start_post);
     reg("/api/pair-device/stop",         HTTP_POST, api_pair_device_stop_post);
     reg("/api/pair-device/status",       HTTP_GET,  api_pair_device_status_get);
+    reg("/api/send-key/start",           HTTP_POST, api_send_key_start_post);
+    reg("/api/send-key/stop",            HTTP_POST, api_send_key_stop_post);
+    reg("/api/send-key/status",          HTTP_GET,  api_send_key_status_get);
     reg("/api/remote/capture/start",  HTTP_POST, api_capture_start_post);
     reg("/api/remote/capture/cancel", HTTP_POST, api_capture_cancel_post);
 

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -595,28 +595,37 @@ namespace iohome
               // Listen and get the key!
               RxFrameQueueItem challengeItem, keyTransferItem;
               uint8_t decrypted_key[AES_KEY_SIZE];
-              if (xQueueReceive(sRxIoQueue, &challengeItem, RECEIVED_IO_TREATMENT_WAIT_TICKS)                                                      // Did we receive a frame?
-                  && challengeItem.frame.command_id == CMD_CHALLENGE_REQUEST                                                                       // Is it a challenge?
-                  && challengeItem.frame.data_len == HMAC_SIZE                                                                                     // Does it contain correct data length?
-                  && xQueueReceive(sRxIoQueue, &keyTransferItem, RECEIVED_IO_TREATMENT_WAIT_TICKS)                                                 // Did we receive another frame?
-                  && keyTransferItem.frame.command_id == CMD_KEY_TRANSFER                                                                          // Is it a key transfer?
-                  && keyTransferItem.frame.data_len == AES_KEY_SIZE                                                                                // Does it contain correct data length?
-                  && iohome::crypto::crypt_2w_key(&item.frame.command_id, 1, challengeItem.frame.data, keyTransferItem.frame.data, decrypted_key)) // decrypt...
+              if (xQueueReceive(sRxIoQueue, &challengeItem, RECEIVED_IO_TREATMENT_WAIT_TICKS)      // Did we receive a frame?
+                  && challengeItem.frame.command_id == CMD_CHALLENGE_REQUEST                        // Is it a challenge?
+                  && challengeItem.frame.data_len == HMAC_SIZE                                      // Does it contain correct data length?
+                  && xQueueReceive(sRxIoQueue, &keyTransferItem, RECEIVED_IO_TREATMENT_WAIT_TICKS) // Did we receive another frame?
+                  && keyTransferItem.frame.command_id == CMD_KEY_TRANSFER                           // Is it a key transfer?
+                  && keyTransferItem.frame.data_len == AES_KEY_SIZE)                                // Does it contain correct data length?
               {
-                std::string hexKey = buffToHexString(AES_KEY_SIZE, decrypted_key);
-                IO_LOGI("Extracted a key to control device {}: {}", buffToHexString(NODE_ID_SIZE, keyTransferItem.frame.dest_node), hexKey);
-                if (sSniffKeyActive)
+                uint8_t challenge_fd[1 + HMAC_SIZE];
+                challenge_fd[0] = challengeItem.frame.command_id;
+                memcpy(challenge_fd + 1, challengeItem.frame.data, HMAC_SIZE);
+                if (iohome::crypto::crypt_2w_key(challenge_fd, sizeof(challenge_fd), challengeItem.frame.data, keyTransferItem.frame.data, decrypted_key))
                 {
-                  strncpy(sSniffedKey, hexKey.c_str(), 32);
-                  sSniffedKey[32] = '\0';
-                  sSniffKeyActive = false;
-                  if (sKeySniffCallback)
-                    sKeySniffCallback(hexKey);
+                  std::string hexKey = buffToHexString(AES_KEY_SIZE, decrypted_key);
+                  IO_LOGI("Extracted a key to control device {}: {}", buffToHexString(NODE_ID_SIZE, keyTransferItem.frame.dest_node), hexKey);
+                  if (sSniffKeyActive)
+                  {
+                    strncpy(sSniffedKey, hexKey.c_str(), 32);
+                    sSniffedKey[32] = '\0';
+                    sSniffKeyActive = false;
+                    if (sKeySniffCallback)
+                      sKeySniffCallback(hexKey);
+                  }
+                }
+                else
+                {
+                  IO_LOGE("ProcessReceivedFrameTask - Failed to decrypt the key!");
                 }
               }
               else
               {
-                IO_LOGE("ProcessReceivedFrameTask - Failed to extract the key!");
+                IO_LOGE("ProcessReceivedFrameTask - Failed to receive challenge/key frames!");
               }
             }
             break;
@@ -978,8 +987,6 @@ namespace iohome
 
     RxFrameQueueItem rxItem;
 
-    uint8_t tahoma_3c_challenge[HMAC_SIZE];
-
     // Wait for CMD 29 within timeout_ms, skipping CMD 28/2A/2E broadcasts.
     auto wait_for_cmd29 = [&](RxFrameQueueItem &item, int timeout_ms) -> bool {
       int64_t end_us = esp_timer_get_time() + (int64_t)timeout_ms * 1000LL;
@@ -1035,75 +1042,65 @@ namespace iohome
       uint32_t tahoma_freq = rxItem.frequency;
       IO_LOGI("LearnKeyFromController: CMD 29 from {} data[{}]={}", buffToHexString(NODE_ID_SIZE, tahoma_node), rxItem.frame.data_len, buffToHexString(rxItem.frame.data_len, rxItem.frame.data));
 
-      // Step 3: send CMD 31 to TaHoma, requesting it challenge us and share its key.
-      // Sequence: 28 → 29 → ESP sends 31 → TaHoma sends 3C → ESP sends 38 → TaHoma sends 32
-      IoFrame init_frame;
-      if (!create_init_transfer(init_frame, mOwnNodeId, tahoma_node)
-          || !TransmitFrame(init_frame, tahoma_freq, SHORT_PREAMBLE_LENGTH))
-      {
-        IO_LOGE("LearnKeyFromController: failed to send CMD 31");
-        vTaskPrioritySet(NULL, savedPriority);
-        xSemaphoreGive(sMutex);
-        continue;
-      }
-      IO_LOGI("LearnKeyFromController: CMD 31 sent — waiting for CMD 3C");
+      // Steps 3+4: send CMD 38 up to 3 times per CMD 29 cycle.
+      // Same challenge for all retries — TaHoma may respond to any of the 3 attempts and the
+      // challenge must match whichever one it received.
+      // CMD 32 arrives within ~60ms when TaHoma processes CMD 38, so 100ms is sufficient for
+      // attempts 1 and 2. The last attempt uses 1s to give TaHoma time to recover or respond.
+      // Note: 2C/2D confirmation handshake was tested and found to break TaHoma's key exchange —
+      // TaHoma stops responding to CMD 38 with CMD 32 after receiving CMD 2C.
+      uint8_t our_challenge[HMAC_SIZE];
+      esp_fill_random(our_challenge, HMAC_SIZE);
 
-      // Step 4: wait for TaHoma's CMD 3C (challenge to the ESP).
+      bool got32 = false;
+      for (int attempt = 0; attempt < 3 && !got32; ++attempt)
       {
-        RxFrameQueueItem item3c;
-        if (!xQueueReceive(sRxIoQueue, &item3c, pdMS_TO_TICKS(1000))
-            || item3c.frame.command_id != CMD_CHALLENGE_REQUEST
-            || item3c.frame.data_len != HMAC_SIZE)
+        IoFrame launch_frame;
+        if (!create_launch_key_transfer(launch_frame, mOwnNodeId, tahoma_node, our_challenge)
+            || !TransmitFrame(launch_frame, tahoma_freq, SHORT_PREAMBLE_LENGTH))
         {
-          uint8_t got = item3c.frame.command_id;
-          ESP_LOGW(TAG, "LearnKeyFromController: no CMD 3C after CMD 31 (got 0x%02X) — retrying", got);
-          vTaskPrioritySet(NULL, savedPriority);
-          xSemaphoreGive(sMutex);
+          IO_LOGE("LearnKeyFromController: failed to send CMD 38[{}]", attempt);
+          break;
+        }
+        TickType_t wait = (attempt < 2) ? pdMS_TO_TICKS(100) : pdMS_TO_TICKS(1000);
+        IO_LOGI("LearnKeyFromController: CMD 38[{}] challenge={} — waiting {}ms for CMD 32",
+                attempt, buffToHexString(HMAC_SIZE, our_challenge), (attempt < 2) ? 100 : 1000);
+
+        if (!xQueueReceive(sRxIoQueue, &rxItem, wait))
+        {
+          IO_LOGI("LearnKeyFromController: CMD 38[{}] no frame — retrying", attempt);
           continue;
         }
-        memcpy(tahoma_3c_challenge, item3c.frame.data, HMAC_SIZE);
+        if (rxItem.frame.command_id == CMD_KEY_TRANSFER && rxItem.frame.data_len == AES_KEY_SIZE)
+        {
+          got32 = true;
+        }
+        else
+        {
+          IO_LOGI("LearnKeyFromController: CMD 38[{}] rx 0x{:02X} from {} — retrying",
+                  attempt, rxItem.frame.command_id,
+                  buffToHexString(NODE_ID_SIZE, rxItem.frame.src_node));
+        }
       }
-      ESP_LOGI(TAG, "LearnKeyFromController: CMD 3C from TaHoma challenge=%s",
-               buffToHexString(HMAC_SIZE, tahoma_3c_challenge).c_str());
-
-      // Step 5: send CMD 38 with TaHoma's CMD 3C data as the challenge.
-      IoFrame launch_frame;
-      if (!create_launch_key_transfer(launch_frame, mOwnNodeId, tahoma_node, tahoma_3c_challenge)
-          || !TransmitFrame(launch_frame, tahoma_freq, SHORT_PREAMBLE_LENGTH))
-      {
-        IO_LOGE("LearnKeyFromController: failed to send CMD 38");
-        vTaskPrioritySet(NULL, savedPriority);
-        xSemaphoreGive(sMutex);
-        continue;
-      }
-      IO_LOGI("LearnKeyFromController: CMD 38 sent — waiting for CMD 32");
-
-      // Step 6: wait for CMD 32 (TaHoma's encrypted system key).
-      if (!xQueueReceive(sRxIoQueue, &rxItem, RECEIVED_IO_TREATMENT_WAIT_TICKS)
-          || rxItem.frame.command_id != CMD_KEY_TRANSFER
-          || rxItem.frame.data_len != AES_KEY_SIZE)
-      {
-        IO_LOGE("LearnKeyFromController: no CMD 32 received");
+      if (!got32) {
         vTaskPrioritySet(NULL, savedPriority);
         xSemaphoreGive(sMutex);
         continue;
       }
 
-      // Step 7: decrypt TaHoma's key.
-      // Log raw CMD 32 and try both possible IV frame bytes (0x38 and 0x31) — log both
-      // results until we confirm which produces the correct key.
+      // Step 5: decrypt TaHoma's system key.
+      // IV frame_data = [CMD_38, challenge[0..5]] — command byte + challenge payload, matching TaHoma's construction.
+      uint8_t cmd38_fd[1 + HMAC_SIZE];
+      cmd38_fd[0] = CMD_LAUNCH_KEY_TRANSFER;
+      memcpy(cmd38_fd + 1, our_challenge, HMAC_SIZE);
+      uint8_t decrypted_key[AES_KEY_SIZE];
+      iohome::crypto::crypt_2w_key(cmd38_fd, sizeof(cmd38_fd), our_challenge, rxItem.frame.data, decrypted_key);
       ESP_LOGI(TAG, "LearnKeyFromController: CMD 32 raw=%s",
                buffToHexString(AES_KEY_SIZE, rxItem.frame.data).c_str());
-      uint8_t cmd38_byte = CMD_LAUNCH_KEY_TRANSFER;   // 0x38
-      uint8_t cmd31_byte = CMD_KEY_INIT_TRANSFER;     // 0x31
-      uint8_t decrypted_38[AES_KEY_SIZE], decrypted_31[AES_KEY_SIZE];
-      iohome::crypto::crypt_2w_key(&cmd38_byte, 1, tahoma_3c_challenge, rxItem.frame.data, decrypted_38);
-      iohome::crypto::crypt_2w_key(&cmd31_byte, 1, tahoma_3c_challenge, rxItem.frame.data, decrypted_31);
-      ESP_LOGI(TAG, "LearnKeyFromController: key(0x38+3C)=%s", buffToHexString(AES_KEY_SIZE, decrypted_38).c_str());
-      ESP_LOGI(TAG, "LearnKeyFromController: key(0x31+3C)=%s", buffToHexString(AES_KEY_SIZE, decrypted_31).c_str());
+      ESP_LOGI(TAG, "LearnKeyFromController: system key=%s",
+               buffToHexString(AES_KEY_SIZE, decrypted_key).c_str());
 
-      // Use 0x38 variant as primary result — both are logged above for comparison.
-      std::string result = buffToHexString(AES_KEY_SIZE, decrypted_38);
+      std::string result = buffToHexString(AES_KEY_SIZE, decrypted_key);
       IO_LOGI("LearnKeyFromController: key received: {}", result);
 
       vTaskPrioritySet(NULL, savedPriority);
@@ -1205,41 +1202,30 @@ namespace iohome
       ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 3C received challenge=%s",
                buffToHexString(HMAC_SIZE, challenge).c_str());
 
-      // Step 4: send CMD 38 with the challenge.
-      IoFrame launch_frame;
-      if (!create_launch_key_transfer(launch_frame, mOwnNodeId, tahoma_node, challenge)
-          || !TransmitFrame(launch_frame, tahoma_freq, SHORT_PREAMBLE_LENGTH))
+      // Step 4: send CMD 32 — encrypt our system key with the challenge and push it to TaHoma.
+      IoFrame key_frame;
+      if (!create_key_transfer(key_frame, init_frame, tahoma_node, mOwnNodeId, mSystemKey, challenge)
+          || !TransmitFrame(key_frame, tahoma_freq, SHORT_PREAMBLE_LENGTH))
       {
-        IO_LOGE("WaitAndRespondToCmd28: failed to send CMD 38");
+        IO_LOGE("WaitAndRespondToCmd28: failed to send CMD 32");
         vTaskPrioritySet(NULL, savedPriority);
         xSemaphoreGive(sMutex);
         continue;
       }
-      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 38 sent — waiting for CMD 32");
+      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 32 sent — waiting for CMD 33 confirmation");
 
-      // Step 5: wait for CMD 32 (TaHoma's encrypted key).
-      RxFrameQueueItem keyItem;
-      if (!xQueueReceive(sRxIoQueue, &keyItem, RECEIVED_IO_TREATMENT_WAIT_TICKS)
-          || keyItem.frame.command_id != CMD_KEY_TRANSFER
-          || keyItem.frame.data_len != AES_KEY_SIZE)
+      // Step 5: wait for CMD 33 (TaHoma confirms key received).
+      RxFrameQueueItem confirmItem;
+      if (!xQueueReceive(sRxIoQueue, &confirmItem, RECEIVED_IO_TREATMENT_WAIT_TICKS)
+          || confirmItem.frame.command_id != CMD_KEY_TRANSFER_CONFIRMATION)
       {
-        ESP_LOGW(TAG, "WaitAndRespondToCmd28: no CMD 32 (got 0x%02X) — retrying", keyItem.frame.command_id);
+        ESP_LOGW(TAG, "WaitAndRespondToCmd28: no CMD 33 confirmation (got 0x%02X) — retrying",
+                 confirmItem.frame.command_id);
         vTaskPrioritySet(NULL, savedPriority);
         xSemaphoreGive(sMutex);
         continue;
       }
-
-      // Step 6: decrypt and log — try both IV frame bytes.
-      uint8_t key38[AES_KEY_SIZE], key31[AES_KEY_SIZE];
-      uint8_t iv38 = CMD_LAUNCH_KEY_TRANSFER, iv31 = CMD_KEY_INIT_TRANSFER;
-      iohome::crypto::crypt_2w_key(&iv38, 1, challenge, keyItem.frame.data, key38);
-      iohome::crypto::crypt_2w_key(&iv31, 1, challenge, keyItem.frame.data, key31);
-      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 32 raw=%s",
-               buffToHexString(AES_KEY_SIZE, keyItem.frame.data).c_str());
-      ESP_LOGI(TAG, "WaitAndRespondToCmd28: key(iv=0x38)=%s",
-               buffToHexString(AES_KEY_SIZE, key38).c_str());
-      ESP_LOGI(TAG, "WaitAndRespondToCmd28: key(iv=0x31)=%s",
-               buffToHexString(AES_KEY_SIZE, key31).c_str());
+      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 33 received — key transfer complete");
 
       vTaskPrioritySet(NULL, savedPriority);
       xSemaphoreGive(sMutex);
@@ -1397,8 +1383,11 @@ namespace iohome
         else
         {
           ESP_LOGI(TAG, "PairAsDevice: CMD 32 received — decrypting key");
+          uint8_t challenge_fd[1 + HMAC_SIZE];
+          challenge_fd[0] = challenge_item.frame.command_id;
+          memcpy(challenge_fd + 1, challenge_item.frame.data, HMAC_SIZE);
           uint8_t decrypted_key[AES_KEY_SIZE];
-          if (!iohome::crypto::crypt_2w_key(&key_init_frame.command_id, 1,
+          if (!iohome::crypto::crypt_2w_key(challenge_fd, sizeof(challenge_fd),
                                              challenge_item.frame.data,
                                              key_item.frame.data, decrypted_key))
           {

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -1033,7 +1033,7 @@ namespace iohome
       uint8_t tahoma_node[NODE_ID_SIZE];
       memcpy(tahoma_node, rxItem.frame.src_node, NODE_ID_SIZE);
       uint32_t tahoma_freq = rxItem.frequency;
-      IO_LOGI("LearnKeyFromController: CMD 29 from {}", buffToHexString(NODE_ID_SIZE, tahoma_node));
+      IO_LOGI("LearnKeyFromController: CMD 29 from {} data[{}]={}", buffToHexString(NODE_ID_SIZE, tahoma_node), rxItem.frame.data_len, buffToHexString(rxItem.frame.data_len, rxItem.frame.data));
 
       // Step 3: send CMD 31 to TaHoma, requesting it challenge us and share its key.
       // Sequence: 28 → 29 → ESP sends 31 → TaHoma sends 3C → ESP sends 38 → TaHoma sends 32
@@ -1175,8 +1175,8 @@ namespace iohome
       }
       ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 29 sent (type=1023/controller) — observing TaHoma response");
 
-      // Collect whatever TaHoma sends in the next 2 s
-      int64_t obs_end = esp_timer_get_time() + 2000000LL;
+      // Collect whatever TaHoma sends in the next 20 s
+      int64_t obs_end = esp_timer_get_time() + 20000000LL;
       while (esp_timer_get_time() < obs_end)
       {
         RxFrameQueueItem obs;
@@ -1184,10 +1184,11 @@ namespace iohome
         if (rem_us <= 0) break;
         TickType_t ticks = (TickType_t)(rem_us / 1000 / portTICK_PERIOD_MS);
         if (ticks == 0) ticks = 1;
-        if (!xQueueReceive(sRxIoQueue, &obs, ticks)) break;
-        ESP_LOGI(TAG, "WaitAndRespondToCmd28: TaHoma sent CMD 0x%02X from %s data[%u]=%s",
+        if (!xQueueReceive(sRxIoQueue, &obs, ticks)) continue;
+        ESP_LOGI(TAG, "WaitAndRespondToCmd28: TaHoma sent CMD 0x%02X from %s to %s data[%u]=%s",
                  obs.frame.command_id,
                  buffToHexString(NODE_ID_SIZE, obs.frame.src_node).c_str(),
+                 buffToHexString(NODE_ID_SIZE, obs.frame.dest_node).c_str(),
                  obs.frame.data_len,
                  buffToHexString(obs.frame.data_len, obs.frame.data).c_str());
       }

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -978,6 +978,11 @@ namespace iohome
 
     RxFrameQueueItem rxItem;
 
+    // TaHoma's CMD 3C challenge persists across retry iterations: TaHoma may send
+    // CMD 32 on iteration N using the CMD 3C challenge it sent on iteration N-1.
+    uint8_t tahoma_3c_challenge[HMAC_SIZE];
+    bool have_tahoma_3c = false;
+
     // Wait for CMD 29 within timeout_ms, skipping CMD 28/2A/2E broadcasts.
     auto wait_for_cmd29 = [&](RxFrameQueueItem &item, int timeout_ms) -> bool {
       int64_t end_us = esp_timer_get_time() + (int64_t)timeout_ms * 1000LL;
@@ -1046,24 +1051,50 @@ namespace iohome
         xSemaphoreGive(sMutex);
         continue;
       }
-      IO_LOGI("LearnKeyFromController: CMD 38 sent — waiting for CMD 32");
+      IO_LOGI("LearnKeyFromController: CMD 38 sent — waiting for CMD 3C/32");
 
-      // Step 4: wait for CMD 32 (TaHoma's system key, encrypted with TRANSFER_KEY + our CMD 38 challenge)
-      if (!xQueueReceive(sRxIoQueue, &rxItem, RECEIVED_IO_TREATMENT_WAIT_TICKS)
-          || rxItem.frame.command_id != CMD_KEY_TRANSFER
-          || rxItem.frame.data_len != AES_KEY_SIZE)
+      // Step 4: TaHoma sends CMD 3C (its own challenge) before CMD 32.
+      // CMD 32 is encrypted with TaHoma's CMD 3C data, NOT our CMD 38 challenge.
+      // Capture CMD 3C first; fall back to our_challenge only if CMD 32 arrives directly.
+      bool got_cmd32 = false;
       {
+        RxFrameQueueItem first;
+        if (xQueueReceive(sRxIoQueue, &first, pdMS_TO_TICKS(250))) {
+          if (first.frame.command_id == CMD_CHALLENGE_REQUEST && first.frame.data_len == HMAC_SIZE) {
+            memcpy(tahoma_3c_challenge, first.frame.data, HMAC_SIZE);
+            have_tahoma_3c = true;
+            ESP_LOGI(TAG, "LearnKeyFromController: CMD 3C from TaHoma challenge=%s",
+                     buffToHexString(HMAC_SIZE, tahoma_3c_challenge).c_str());
+            // Now wait for CMD 32 that follows CMD 3C
+            if (xQueueReceive(sRxIoQueue, &rxItem, RECEIVED_IO_TREATMENT_WAIT_TICKS)
+                && rxItem.frame.command_id == CMD_KEY_TRANSFER
+                && rxItem.frame.data_len == AES_KEY_SIZE) {
+              got_cmd32 = true;
+            }
+          } else if (first.frame.command_id == CMD_KEY_TRANSFER && first.frame.data_len == AES_KEY_SIZE) {
+            rxItem    = first;
+            got_cmd32 = true;
+          }
+        }
+      }
+      if (!got_cmd32) {
         IO_LOGE("LearnKeyFromController: no CMD 32 received");
         vTaskPrioritySet(NULL, savedPriority);
         xSemaphoreGive(sMutex);
         continue;
       }
-      IO_LOGI("LearnKeyFromController: CMD 32 received — decrypting");
 
-      // Step 5: decrypt TaHoma's key — frame_data = CMD 38 byte, IV = our random challenge.
+      // Step 5: decrypt TaHoma's key.
+      // Use TaHoma's CMD 3C challenge when available; fall back to our CMD 38 challenge.
+      const uint8_t *decrypt_challenge = have_tahoma_3c ? tahoma_3c_challenge : our_challenge;
+      IO_LOGI("LearnKeyFromController: CMD 32 received — decrypting with %s challenge",
+              have_tahoma_3c ? "TaHoma CMD 3C" : "our CMD 38");
+      ESP_LOGI(TAG, "LearnKeyFromController: CMD 32 raw=%s",
+               buffToHexString(AES_KEY_SIZE, rxItem.frame.data).c_str());
+
       uint8_t cmd38_byte = CMD_LAUNCH_KEY_TRANSFER;
       uint8_t decrypted_key[AES_KEY_SIZE];
-      if (!iohome::crypto::crypt_2w_key(&cmd38_byte, 1, our_challenge, rxItem.frame.data, decrypted_key))
+      if (!iohome::crypto::crypt_2w_key(&cmd38_byte, 1, decrypt_challenge, rxItem.frame.data, decrypted_key))
       {
         IO_LOGE("LearnKeyFromController: key decryption failed");
         vTaskPrioritySet(NULL, savedPriority);

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -1173,25 +1173,73 @@ namespace iohome
         xSemaphoreGive(sMutex);
         continue;
       }
-      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 29 sent (type=1023/controller) — observing TaHoma response");
+      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 29 sent — sending CMD 31 to request key exchange");
 
-      // Collect whatever TaHoma sends in the next 20 s
-      int64_t obs_end = esp_timer_get_time() + 20000000LL;
-      while (esp_timer_get_time() < obs_end)
+      // Step 2: send CMD 31 to request TaHoma challenges us and shares its key.
+      IoFrame init_frame;
+      if (!create_init_transfer(init_frame, mOwnNodeId, tahoma_node)
+          || !TransmitFrame(init_frame, tahoma_freq, SHORT_PREAMBLE_LENGTH))
       {
-        RxFrameQueueItem obs;
-        int64_t rem_us = obs_end - esp_timer_get_time();
-        if (rem_us <= 0) break;
-        TickType_t ticks = (TickType_t)(rem_us / 1000 / portTICK_PERIOD_MS);
-        if (ticks == 0) ticks = 1;
-        if (!xQueueReceive(sRxIoQueue, &obs, ticks)) continue;
-        ESP_LOGI(TAG, "WaitAndRespondToCmd28: TaHoma sent CMD 0x%02X from %s to %s data[%u]=%s",
-                 obs.frame.command_id,
-                 buffToHexString(NODE_ID_SIZE, obs.frame.src_node).c_str(),
-                 buffToHexString(NODE_ID_SIZE, obs.frame.dest_node).c_str(),
-                 obs.frame.data_len,
-                 buffToHexString(obs.frame.data_len, obs.frame.data).c_str());
+        IO_LOGE("WaitAndRespondToCmd28: failed to send CMD 31");
+        vTaskPrioritySet(NULL, savedPriority);
+        xSemaphoreGive(sMutex);
+        continue;
       }
+      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 31 sent — waiting for CMD 3C");
+
+      // Step 3: wait for TaHoma's CMD 3C challenge.
+      uint8_t challenge[HMAC_SIZE];
+      {
+        RxFrameQueueItem item3c;
+        if (!xQueueReceive(sRxIoQueue, &item3c, pdMS_TO_TICKS(2000))
+            || item3c.frame.command_id != CMD_CHALLENGE_REQUEST
+            || item3c.frame.data_len != HMAC_SIZE)
+        {
+          ESP_LOGW(TAG, "WaitAndRespondToCmd28: no CMD 3C (got 0x%02X) — retrying", item3c.frame.command_id);
+          vTaskPrioritySet(NULL, savedPriority);
+          xSemaphoreGive(sMutex);
+          continue;
+        }
+        memcpy(challenge, item3c.frame.data, HMAC_SIZE);
+      }
+      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 3C received challenge=%s",
+               buffToHexString(HMAC_SIZE, challenge).c_str());
+
+      // Step 4: send CMD 38 with the challenge.
+      IoFrame launch_frame;
+      if (!create_launch_key_transfer(launch_frame, mOwnNodeId, tahoma_node, challenge)
+          || !TransmitFrame(launch_frame, tahoma_freq, SHORT_PREAMBLE_LENGTH))
+      {
+        IO_LOGE("WaitAndRespondToCmd28: failed to send CMD 38");
+        vTaskPrioritySet(NULL, savedPriority);
+        xSemaphoreGive(sMutex);
+        continue;
+      }
+      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 38 sent — waiting for CMD 32");
+
+      // Step 5: wait for CMD 32 (TaHoma's encrypted key).
+      RxFrameQueueItem keyItem;
+      if (!xQueueReceive(sRxIoQueue, &keyItem, RECEIVED_IO_TREATMENT_WAIT_TICKS)
+          || keyItem.frame.command_id != CMD_KEY_TRANSFER
+          || keyItem.frame.data_len != AES_KEY_SIZE)
+      {
+        ESP_LOGW(TAG, "WaitAndRespondToCmd28: no CMD 32 (got 0x%02X) — retrying", keyItem.frame.command_id);
+        vTaskPrioritySet(NULL, savedPriority);
+        xSemaphoreGive(sMutex);
+        continue;
+      }
+
+      // Step 6: decrypt and log — try both IV frame bytes.
+      uint8_t key38[AES_KEY_SIZE], key31[AES_KEY_SIZE];
+      uint8_t iv38 = CMD_LAUNCH_KEY_TRANSFER, iv31 = CMD_KEY_INIT_TRANSFER;
+      iohome::crypto::crypt_2w_key(&iv38, 1, challenge, keyItem.frame.data, key38);
+      iohome::crypto::crypt_2w_key(&iv31, 1, challenge, keyItem.frame.data, key31);
+      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 32 raw=%s",
+               buffToHexString(AES_KEY_SIZE, keyItem.frame.data).c_str());
+      ESP_LOGI(TAG, "WaitAndRespondToCmd28: key(iv=0x38)=%s",
+               buffToHexString(AES_KEY_SIZE, key38).c_str());
+      ESP_LOGI(TAG, "WaitAndRespondToCmd28: key(iv=0x31)=%s",
+               buffToHexString(AES_KEY_SIZE, key31).c_str());
 
       vTaskPrioritySet(NULL, savedPriority);
       xSemaphoreGive(sMutex);

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -1130,17 +1130,30 @@ namespace iohome
 
     while ((active == nullptr || *active) && esp_timer_get_time() < deadline)
     {
-      // Wait for any frame from the radio queue
-      RxFrameQueueItem item;
-      if (!xQueueReceive(sRxIoQueue, &item, pdMS_TO_TICKS(2000)))
+      if (!xSemaphoreTake(sMutex, MUTEX_MAX_WAIT_TICKS))
         continue;
 
-      uint8_t cmd = item.frame.command_id;
+      UBaseType_t savedPriority = uxTaskPriorityGet(NULL);
+      vTaskPrioritySet(NULL, IO_FRAME_PROCESSING_TASK);
 
-      if (cmd != CMD_DISCOVER_REQUEST)
+      // Poll for CMD 28 for up to 2 s while holding the mutex (same pattern as LearnKeyFromController).
+      // The main processing loop also reads sRxIoQueue under this mutex, so we must hold it first.
+      RxFrameQueueItem item;
+      bool got28 = false;
+      int64_t poll_end = esp_timer_get_time() + 2000000LL;
+      while (esp_timer_get_time() < poll_end)
       {
-        ESP_LOGI(TAG, "WaitAndRespondToCmd28: skip CMD 0x%02X from %s",
-                 cmd, buffToHexString(NODE_ID_SIZE, item.frame.src_node).c_str());
+        int64_t rem_us = poll_end - esp_timer_get_time();
+        TickType_t ticks = (TickType_t)(rem_us / 1000 / portTICK_PERIOD_MS);
+        if (ticks == 0) ticks = 1;
+        if (!xQueueReceive(sRxIoQueue, &item, ticks)) break;
+        if (item.frame.command_id == CMD_DISCOVER_REQUEST) { got28 = true; break; }
+        ESP_LOGD(TAG, "WaitAndRespondToCmd28: skip CMD 0x%02X", item.frame.command_id);
+      }
+      if (!got28)
+      {
+        vTaskPrioritySet(NULL, savedPriority);
+        xSemaphoreGive(sMutex);
         continue;
       }
 
@@ -1149,12 +1162,6 @@ namespace iohome
       uint32_t tahoma_freq = item.frequency;
       ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 28 from %s freq=%lu",
                buffToHexString(NODE_ID_SIZE, tahoma_node).c_str(), (unsigned long)tahoma_freq);
-
-      if (!xSemaphoreTake(sMutex, MUTEX_MAX_WAIT_TICKS))
-        continue;
-
-      UBaseType_t savedPriority = uxTaskPriorityGet(NULL);
-      vTaskPrioritySet(NULL, IO_FRAME_PROCESSING_TASK);
 
       // Respond with CMD 29 using controller device type 1023 (0x3FF → data bytes FF C0)
       IoFrame resp;

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -1038,30 +1038,28 @@ namespace iohome
       uint32_t tahoma_freq = rxItem.frequency;
       IO_LOGI("LearnKeyFromController: CMD 29 from {}", buffToHexString(NODE_ID_SIZE, tahoma_node));
 
-      // Step 3: wait for TaHoma's CMD 31 (key init — TaHoma offers its key).
-      // Expected sequence: 29 → 31 → 3C → 38 → 32
+      // Step 3: send CMD 31 to TaHoma, requesting it challenge us and share its key.
+      // Sequence: 28 → 29 → ESP sends 31 → TaHoma sends 3C → ESP sends 38 → TaHoma sends 32
+      IoFrame init_frame;
+      if (!create_init_transfer(init_frame, mOwnNodeId, tahoma_node)
+          || !TransmitFrame(init_frame, tahoma_freq, SHORT_PREAMBLE_LENGTH))
       {
-        RxFrameQueueItem item31;
-        if (!xQueueReceive(sRxIoQueue, &item31, pdMS_TO_TICKS(1000))
-            || item31.frame.command_id != CMD_KEY_INIT_TRANSFER)
-        {
-          uint8_t got = item31.frame.command_id;
-          ESP_LOGW(TAG, "LearnKeyFromController: no CMD 31 (got 0x%02X) — retrying", got);
-          vTaskPrioritySet(NULL, savedPriority);
-          xSemaphoreGive(sMutex);
-          continue;
-        }
+        IO_LOGE("LearnKeyFromController: failed to send CMD 31");
+        vTaskPrioritySet(NULL, savedPriority);
+        xSemaphoreGive(sMutex);
+        continue;
       }
-      ESP_LOGI(TAG, "LearnKeyFromController: CMD 31 received");
+      IO_LOGI("LearnKeyFromController: CMD 31 sent — waiting for CMD 3C");
 
-      // Step 4: wait for TaHoma's CMD 3C (TaHoma's challenge to the ESP).
+      // Step 4: wait for TaHoma's CMD 3C (challenge to the ESP).
       {
         RxFrameQueueItem item3c;
         if (!xQueueReceive(sRxIoQueue, &item3c, pdMS_TO_TICKS(1000))
             || item3c.frame.command_id != CMD_CHALLENGE_REQUEST
             || item3c.frame.data_len != HMAC_SIZE)
         {
-          ESP_LOGW(TAG, "LearnKeyFromController: no CMD 3C after CMD 31 — retrying");
+          uint8_t got = item3c.frame.command_id;
+          ESP_LOGW(TAG, "LearnKeyFromController: no CMD 3C after CMD 31 (got 0x%02X) — retrying", got);
           vTaskPrioritySet(NULL, savedPriority);
           xSemaphoreGive(sMutex);
           continue;
@@ -1073,7 +1071,6 @@ namespace iohome
                buffToHexString(HMAC_SIZE, tahoma_3c_challenge).c_str());
 
       // Step 5: send CMD 38 with TaHoma's CMD 3C data as the challenge.
-      // TaHoma uses the challenge to encrypt CMD 32; echoing it back makes the IV deterministic.
       IoFrame launch_frame;
       if (!create_launch_key_transfer(launch_frame, mOwnNodeId, tahoma_node, tahoma_3c_challenge)
           || !TransmitFrame(launch_frame, tahoma_freq, SHORT_PREAMBLE_LENGTH))
@@ -1098,7 +1095,7 @@ namespace iohome
 
       // Step 7: decrypt TaHoma's key.
       // Log raw CMD 32 and try both possible IV frame bytes (0x38 and 0x31) — log both
-      // results until we confirm which frame byte TaHoma uses for encryption.
+      // results until we confirm which produces the correct key.
       ESP_LOGI(TAG, "LearnKeyFromController: CMD 32 raw=%s",
                buffToHexString(AES_KEY_SIZE, rxItem.frame.data).c_str());
       uint8_t cmd38_byte = CMD_LAUNCH_KEY_TRANSFER;   // 0x38
@@ -1106,8 +1103,8 @@ namespace iohome
       uint8_t decrypted_38[AES_KEY_SIZE], decrypted_31[AES_KEY_SIZE];
       iohome::crypto::crypt_2w_key(&cmd38_byte, 1, tahoma_3c_challenge, rxItem.frame.data, decrypted_38);
       iohome::crypto::crypt_2w_key(&cmd31_byte, 1, tahoma_3c_challenge, rxItem.frame.data, decrypted_31);
-      ESP_LOGI(TAG, "LearnKeyFromController: key(IV=0x38)=%s", buffToHexString(AES_KEY_SIZE, decrypted_38).c_str());
-      ESP_LOGI(TAG, "LearnKeyFromController: key(IV=0x31)=%s", buffToHexString(AES_KEY_SIZE, decrypted_31).c_str());
+      ESP_LOGI(TAG, "LearnKeyFromController: key(0x38+3C)=%s", buffToHexString(AES_KEY_SIZE, decrypted_38).c_str());
+      ESP_LOGI(TAG, "LearnKeyFromController: key(0x31+3C)=%s", buffToHexString(AES_KEY_SIZE, decrypted_31).c_str());
 
       // Use 0x38 variant as primary result — both are logged above for comparison.
       std::string result = buffToHexString(AES_KEY_SIZE, decrypted_38);

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -1038,12 +1038,44 @@ namespace iohome
       uint32_t tahoma_freq = rxItem.frequency;
       IO_LOGI("LearnKeyFromController: CMD 29 from {}", buffToHexString(NODE_ID_SIZE, tahoma_node));
 
-      // Step 3: send CMD 38 with a fresh random challenge — Path 1 (receiver requests key).
-      // TaHoma is in key-send mode: it waits for CMD 38 and replies with CMD 32.
-      uint8_t our_challenge[HMAC_SIZE];
-      iohome::crypto::generate_challenge(our_challenge);
+      // Step 3: wait for TaHoma's CMD 31 (key init — TaHoma offers its key).
+      // Expected sequence: 29 → 31 → 3C → 38 → 32
+      {
+        RxFrameQueueItem item31;
+        if (!xQueueReceive(sRxIoQueue, &item31, pdMS_TO_TICKS(1000))
+            || item31.frame.command_id != CMD_KEY_INIT_TRANSFER)
+        {
+          uint8_t got = item31.frame.command_id;
+          ESP_LOGW(TAG, "LearnKeyFromController: no CMD 31 (got 0x%02X) — retrying", got);
+          vTaskPrioritySet(NULL, savedPriority);
+          xSemaphoreGive(sMutex);
+          continue;
+        }
+      }
+      ESP_LOGI(TAG, "LearnKeyFromController: CMD 31 received");
+
+      // Step 4: wait for TaHoma's CMD 3C (TaHoma's challenge to the ESP).
+      {
+        RxFrameQueueItem item3c;
+        if (!xQueueReceive(sRxIoQueue, &item3c, pdMS_TO_TICKS(1000))
+            || item3c.frame.command_id != CMD_CHALLENGE_REQUEST
+            || item3c.frame.data_len != HMAC_SIZE)
+        {
+          ESP_LOGW(TAG, "LearnKeyFromController: no CMD 3C after CMD 31 — retrying");
+          vTaskPrioritySet(NULL, savedPriority);
+          xSemaphoreGive(sMutex);
+          continue;
+        }
+        memcpy(tahoma_3c_challenge, item3c.frame.data, HMAC_SIZE);
+        have_tahoma_3c = true;
+      }
+      ESP_LOGI(TAG, "LearnKeyFromController: CMD 3C from TaHoma challenge=%s",
+               buffToHexString(HMAC_SIZE, tahoma_3c_challenge).c_str());
+
+      // Step 5: send CMD 38 with TaHoma's CMD 3C data as the challenge.
+      // TaHoma uses the challenge to encrypt CMD 32; echoing it back makes the IV deterministic.
       IoFrame launch_frame;
-      if (!create_launch_key_transfer(launch_frame, mOwnNodeId, tahoma_node, our_challenge)
+      if (!create_launch_key_transfer(launch_frame, mOwnNodeId, tahoma_node, tahoma_3c_challenge)
           || !TransmitFrame(launch_frame, tahoma_freq, SHORT_PREAMBLE_LENGTH))
       {
         IO_LOGE("LearnKeyFromController: failed to send CMD 38");
@@ -1051,58 +1083,34 @@ namespace iohome
         xSemaphoreGive(sMutex);
         continue;
       }
-      IO_LOGI("LearnKeyFromController: CMD 38 sent — waiting for CMD 3C/32");
+      IO_LOGI("LearnKeyFromController: CMD 38 sent — waiting for CMD 32");
 
-      // Step 4: TaHoma sends CMD 3C (its own challenge) before CMD 32.
-      // CMD 32 is encrypted with TaHoma's CMD 3C data, NOT our CMD 38 challenge.
-      // Capture CMD 3C first; fall back to our_challenge only if CMD 32 arrives directly.
-      bool got_cmd32 = false;
+      // Step 6: wait for CMD 32 (TaHoma's encrypted system key).
+      if (!xQueueReceive(sRxIoQueue, &rxItem, RECEIVED_IO_TREATMENT_WAIT_TICKS)
+          || rxItem.frame.command_id != CMD_KEY_TRANSFER
+          || rxItem.frame.data_len != AES_KEY_SIZE)
       {
-        RxFrameQueueItem first;
-        if (xQueueReceive(sRxIoQueue, &first, pdMS_TO_TICKS(250))) {
-          if (first.frame.command_id == CMD_CHALLENGE_REQUEST && first.frame.data_len == HMAC_SIZE) {
-            memcpy(tahoma_3c_challenge, first.frame.data, HMAC_SIZE);
-            have_tahoma_3c = true;
-            ESP_LOGI(TAG, "LearnKeyFromController: CMD 3C from TaHoma challenge=%s",
-                     buffToHexString(HMAC_SIZE, tahoma_3c_challenge).c_str());
-            // Now wait for CMD 32 that follows CMD 3C
-            if (xQueueReceive(sRxIoQueue, &rxItem, RECEIVED_IO_TREATMENT_WAIT_TICKS)
-                && rxItem.frame.command_id == CMD_KEY_TRANSFER
-                && rxItem.frame.data_len == AES_KEY_SIZE) {
-              got_cmd32 = true;
-            }
-          } else if (first.frame.command_id == CMD_KEY_TRANSFER && first.frame.data_len == AES_KEY_SIZE) {
-            rxItem    = first;
-            got_cmd32 = true;
-          }
-        }
-      }
-      if (!got_cmd32) {
         IO_LOGE("LearnKeyFromController: no CMD 32 received");
         vTaskPrioritySet(NULL, savedPriority);
         xSemaphoreGive(sMutex);
         continue;
       }
 
-      // Step 5: decrypt TaHoma's key.
-      // Use TaHoma's CMD 3C challenge when available; fall back to our CMD 38 challenge.
-      const uint8_t *decrypt_challenge = have_tahoma_3c ? tahoma_3c_challenge : our_challenge;
-      IO_LOGI("LearnKeyFromController: CMD 32 received — decrypting with %s challenge",
-              have_tahoma_3c ? "TaHoma CMD 3C" : "our CMD 38");
+      // Step 7: decrypt TaHoma's key.
+      // Log raw CMD 32 and try both possible IV frame bytes (0x38 and 0x31) — log both
+      // results until we confirm which frame byte TaHoma uses for encryption.
       ESP_LOGI(TAG, "LearnKeyFromController: CMD 32 raw=%s",
                buffToHexString(AES_KEY_SIZE, rxItem.frame.data).c_str());
+      uint8_t cmd38_byte = CMD_LAUNCH_KEY_TRANSFER;   // 0x38
+      uint8_t cmd31_byte = CMD_KEY_INIT_TRANSFER;     // 0x31
+      uint8_t decrypted_38[AES_KEY_SIZE], decrypted_31[AES_KEY_SIZE];
+      iohome::crypto::crypt_2w_key(&cmd38_byte, 1, tahoma_3c_challenge, rxItem.frame.data, decrypted_38);
+      iohome::crypto::crypt_2w_key(&cmd31_byte, 1, tahoma_3c_challenge, rxItem.frame.data, decrypted_31);
+      ESP_LOGI(TAG, "LearnKeyFromController: key(IV=0x38)=%s", buffToHexString(AES_KEY_SIZE, decrypted_38).c_str());
+      ESP_LOGI(TAG, "LearnKeyFromController: key(IV=0x31)=%s", buffToHexString(AES_KEY_SIZE, decrypted_31).c_str());
 
-      uint8_t cmd38_byte = CMD_LAUNCH_KEY_TRANSFER;
-      uint8_t decrypted_key[AES_KEY_SIZE];
-      if (!iohome::crypto::crypt_2w_key(&cmd38_byte, 1, decrypt_challenge, rxItem.frame.data, decrypted_key))
-      {
-        IO_LOGE("LearnKeyFromController: key decryption failed");
-        vTaskPrioritySet(NULL, savedPriority);
-        xSemaphoreGive(sMutex);
-        continue;
-      }
-
-      std::string result = buffToHexString(AES_KEY_SIZE, decrypted_key);
+      // Use 0x38 variant as primary result — both are logged above for comparison.
+      std::string result = buffToHexString(AES_KEY_SIZE, decrypted_38);
       IO_LOGI("LearnKeyFromController: key received: {}", result);
 
       vTaskPrioritySet(NULL, savedPriority);

--- a/io-homecontrol/IoHomeControl.cpp
+++ b/io-homecontrol/IoHomeControl.cpp
@@ -978,10 +978,7 @@ namespace iohome
 
     RxFrameQueueItem rxItem;
 
-    // TaHoma's CMD 3C challenge persists across retry iterations: TaHoma may send
-    // CMD 32 on iteration N using the CMD 3C challenge it sent on iteration N-1.
     uint8_t tahoma_3c_challenge[HMAC_SIZE];
-    bool have_tahoma_3c = false;
 
     // Wait for CMD 29 within timeout_ms, skipping CMD 28/2A/2E broadcasts.
     auto wait_for_cmd29 = [&](RxFrameQueueItem &item, int timeout_ms) -> bool {
@@ -1065,7 +1062,6 @@ namespace iohome
           continue;
         }
         memcpy(tahoma_3c_challenge, item3c.frame.data, HMAC_SIZE);
-        have_tahoma_3c = true;
       }
       ESP_LOGI(TAG, "LearnKeyFromController: CMD 3C from TaHoma challenge=%s",
                buffToHexString(HMAC_SIZE, tahoma_3c_challenge).c_str());
@@ -1118,6 +1114,82 @@ namespace iohome
 
     IO_LOGI("LearnKeyFromController: session ended (timeout or cancelled)");
     return "";
+  }
+
+  void IoHomeControl::WaitAndRespondToCmd28(const volatile bool *active)
+  {
+    if (!mInitialized || !mReceiving || mPassiveMode)
+    {
+      IO_LOGE("WaitAndRespondToCmd28: invalid state!");
+      return;
+    }
+
+    IO_LOGI("WaitAndRespondToCmd28: session started — listening for TaHoma CMD 28 (30 s)");
+
+    const int64_t deadline = esp_timer_get_time() + 30LL * 1000000LL;
+
+    while ((active == nullptr || *active) && esp_timer_get_time() < deadline)
+    {
+      // Wait for any frame from the radio queue
+      RxFrameQueueItem item;
+      if (!xQueueReceive(sRxIoQueue, &item, pdMS_TO_TICKS(2000)))
+        continue;
+
+      uint8_t cmd = item.frame.command_id;
+
+      if (cmd != CMD_DISCOVER_REQUEST)
+      {
+        ESP_LOGI(TAG, "WaitAndRespondToCmd28: skip CMD 0x%02X from %s",
+                 cmd, buffToHexString(NODE_ID_SIZE, item.frame.src_node).c_str());
+        continue;
+      }
+
+      uint8_t tahoma_node[NODE_ID_SIZE];
+      memcpy(tahoma_node, item.frame.src_node, NODE_ID_SIZE);
+      uint32_t tahoma_freq = item.frequency;
+      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 28 from %s freq=%lu",
+               buffToHexString(NODE_ID_SIZE, tahoma_node).c_str(), (unsigned long)tahoma_freq);
+
+      if (!xSemaphoreTake(sMutex, MUTEX_MAX_WAIT_TICKS))
+        continue;
+
+      UBaseType_t savedPriority = uxTaskPriorityGet(NULL);
+      vTaskPrioritySet(NULL, IO_FRAME_PROCESSING_TASK);
+
+      // Respond with CMD 29 using controller device type 1023 (0x3FF → data bytes FF C0)
+      IoFrame resp;
+      if (!create_discovery_response(resp, mOwnNodeId, tahoma_node, 1023)
+          || !TransmitFrame(resp, tahoma_freq, SHORT_PREAMBLE_LENGTH))
+      {
+        IO_LOGE("WaitAndRespondToCmd28: failed to send CMD 29");
+        vTaskPrioritySet(NULL, savedPriority);
+        xSemaphoreGive(sMutex);
+        continue;
+      }
+      ESP_LOGI(TAG, "WaitAndRespondToCmd28: CMD 29 sent (type=1023/controller) — observing TaHoma response");
+
+      // Collect whatever TaHoma sends in the next 2 s
+      int64_t obs_end = esp_timer_get_time() + 2000000LL;
+      while (esp_timer_get_time() < obs_end)
+      {
+        RxFrameQueueItem obs;
+        int64_t rem_us = obs_end - esp_timer_get_time();
+        if (rem_us <= 0) break;
+        TickType_t ticks = (TickType_t)(rem_us / 1000 / portTICK_PERIOD_MS);
+        if (ticks == 0) ticks = 1;
+        if (!xQueueReceive(sRxIoQueue, &obs, ticks)) break;
+        ESP_LOGI(TAG, "WaitAndRespondToCmd28: TaHoma sent CMD 0x%02X from %s data[%u]=%s",
+                 obs.frame.command_id,
+                 buffToHexString(NODE_ID_SIZE, obs.frame.src_node).c_str(),
+                 obs.frame.data_len,
+                 buffToHexString(obs.frame.data_len, obs.frame.data).c_str());
+      }
+
+      vTaskPrioritySet(NULL, savedPriority);
+      xSemaphoreGive(sMutex);
+    }
+
+    IO_LOGI("WaitAndRespondToCmd28: session ended");
   }
 
   std::string IoHomeControl::PairAsDevice(const volatile bool *active)

--- a/io-homecontrol/IoHomeControl.hpp
+++ b/io-homecontrol/IoHomeControl.hpp
@@ -158,6 +158,11 @@ namespace iohome
     /// @return System key on success, empty string on timeout or cancellation.
     std::string LearnKeyFromController(const volatile bool *active = nullptr);
 
+    /// @brief Wait for TaHoma's CMD 28 broadcast, respond with CMD 29 as a controller, then log
+    /// all frames TaHoma sends next.  Used for step-by-step protocol observation.
+    /// @param active Pointer to a bool the caller can set to false to cancel early.
+    void WaitAndRespondToCmd28(const volatile bool *active = nullptr);
+
     /// @brief Pretend to be a new 2W actuator waiting to be paired.
     /// TaHoma/CK in "add device" mode sends CMD 28 to the broadcast address (0x00003B).
     /// We respond as a ROLLER_SHUTTER device and complete the full key exchange to obtain the system key.

--- a/io-homecontrol/protocol/iohome_commands.cpp
+++ b/io-homecontrol/protocol/iohome_commands.cpp
@@ -228,7 +228,7 @@ namespace iohome
             static_cast<uint8_t>(device_type >> 2),           // upper 6 bits of device type
             static_cast<uint8_t>((device_type & 0x03) << 6),  // lower 2 bits of device type, subtype = 0
             own_node_id[0], own_node_id[1], own_node_id[2],
-            0x02, 0xDC, 0x00, s_counter++
+            0x02, 0xCC, 0x00, s_counter++
         };
         return set_command(frame, CMD_DISCOVER_RESPONSE, data, sizeof(data));
     }

--- a/io-homecontrol/protocol/iohome_commands.cpp
+++ b/io-homecontrol/protocol/iohome_commands.cpp
@@ -228,7 +228,7 @@ namespace iohome
             static_cast<uint8_t>(device_type >> 2),           // upper 6 bits of device type
             static_cast<uint8_t>((device_type & 0x03) << 6),  // lower 2 bits of device type, subtype = 0
             own_node_id[0], own_node_id[1], own_node_id[2],
-            0x02, 0xCC, 0x00, s_counter++
+            0x02, 0xCC, 0x00, 0x00
         };
         return set_command(frame, CMD_DISCOVER_RESPONSE, data, sizeof(data));
     }

--- a/io-homecontrol/protocol/iohome_commands.cpp
+++ b/io-homecontrol/protocol/iohome_commands.cpp
@@ -213,7 +213,7 @@ namespace iohome
         return true;
     }
 
-    bool create_discovery_response(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id, uint8_t device_type)
+    bool create_discovery_response(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id, uint16_t device_type)
     {
         init_frame(frame, true, true, false, false);
         set_destination(frame, dst_node_id);

--- a/io-homecontrol/protocol/iohome_commands.hpp
+++ b/io-homecontrol/protocol/iohome_commands.hpp
@@ -79,7 +79,7 @@ namespace iohome
     /// @param own_node_id Source node ID (3 bytes)
     /// @param dst_node_id Destination node ID (3 bytes)
     /// @return true on success
-    bool create_discovery_response(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id, uint8_t device_type = 0x04);
+    bool create_discovery_response(IoFrame &frame, const uint8_t *own_node_id, const uint8_t *dst_node_id, uint16_t device_type = 0x04);
 
     /// @brief Create a Discovery Confirmation IO Frame (0x2C)
     /// @param frame Output IoFrame structure

--- a/web_data_v2/index.html
+++ b/web_data_v2/index.html
@@ -319,6 +319,7 @@
               <button class="s-btn" id="io-key-sniff">Sniff</button>
               <button class="s-btn" id="io-key-learn">Learn</button>
               <button class="s-btn" id="io-key-pair-device">Pair</button>
+              <button class="s-btn" id="io-key-send-key">Send Key</button>
             </div>
             <span class="field-status" id="io-key-status"></span>
           </div>
@@ -652,6 +653,22 @@
       <button id="io-pair-device-retry"   type="button" class="btn-ghost" style="display:none;">Retry</button>
       <button id="io-pair-device-start"   class="btn-danger-confirm">Start Listening</button>
       <button id="io-pair-device-use-key" class="btn-danger-confirm" style="display:none;">Use This Key</button>
+    </div>
+  </div>
+</div>
+
+<!-- ── SEND KEY OBSERVE MODAL ── -->
+<div id="io-send-key-modal" class="key-modal">
+  <div class="key-modal-inner">
+    <h3>Send Key — Step 1: Observe CMD 28 / CMD 29</h3>
+    <p class="key-modal-warning-text">Trigger "Share key" or "Add controller" in the Somfy app. The ESP will respond to TaHoma's CMD 28 with CMD 29 (controller type) and log what TaHoma sends next. Check Graylog for frame details.</p>
+    <div id="io-send-key-countdown-row" style="display:none;margin:8px 0;font-size:13px;">
+      <span>Listening for TaHoma CMD 28… </span><strong id="io-send-key-countdown"></strong><span> s remaining</span>
+    </div>
+    <p id="io-send-key-status" class="key-modal-status"></p>
+    <div class="key-modal-actions" style="margin-top:12px;">
+      <button id="io-send-key-cancel" type="button" class="btn-ghost">Cancel</button>
+      <button id="io-send-key-start"  class="btn-danger-confirm">Start Observing</button>
     </div>
   </div>
 </div>

--- a/web_data_v2/js/app.js
+++ b/web_data_v2/js/app.js
@@ -202,6 +202,10 @@
                     if (window.MiOpenSettings && window.MiOpenSettings.onPairDeviceKey) {
                         window.MiOpenSettings.onPairDeviceKey(data.key);
                     }
+                } else if (data.type === "send_key_done") {
+                    if (window.MiOpenSettings && window.MiOpenSettings.onSendKeyDone) {
+                        window.MiOpenSettings.onSendKeyDone();
+                    }
                 }
             } catch (e) { /* ignore parse errors */ }
         };

--- a/web_data_v2/js/settings.js
+++ b/web_data_v2/js/settings.js
@@ -506,6 +506,7 @@
 
         initLearnKey(app);
         initPairDeviceKey(app);
+        initSendKey();
         loadIoKey(app);
     }
 
@@ -977,7 +978,6 @@
         onSendKeyDone: onSendKeyDone
     };
 
-    init_hooks.push(function (app) { initSendKey(); });
 })();
 
 // ── Syslog (settings section) ─────────────────────────────────────────────────

--- a/web_data_v2/js/settings.js
+++ b/web_data_v2/js/settings.js
@@ -1,10 +1,11 @@
 (function () {
+    function g(id) { return document.getElementById(id); }
 
     let fallbackStatusTimer = null;
     let mqttStatusTimer = null;
 
     function updateMqttStatusEl(status) {
-        var el = document.getElementById("mqtt-conn-status");
+        var el = g("mqtt-conn-status");
         if (!el) return;
         var map = {
             connected:    { text: "● Connected",   color: "#27ae60" },
@@ -19,7 +20,7 @@
     }
 
     async function pollMqttStatus(app) {
-        var settingsView = document.getElementById("view-settings");
+        var settingsView = g("view-settings");
         if (!settingsView || !settingsView.classList.contains("active")) return;
         try {
             var cfg = await window.MiOpenApi.requestJson("/api/mqtt");
@@ -57,7 +58,7 @@
     }
 
     async function pollFallbackStatus(app) {
-        var settingsView = document.getElementById("view-settings");
+        var settingsView = g("view-settings");
         if (!settingsView || !settingsView.classList.contains("active")) return;
         try {
             const cfg = await window.MiOpenApi.requestJson("/api/wifi/fallback");
@@ -236,15 +237,15 @@
     }
 
     function initNetworkConfig(app) {
-        app.elements.netHostname    = document.getElementById("net-hostname");
-        app.elements.netDhcp        = document.getElementById("net-dhcp");
-        app.elements.netDhcpToggle  = document.getElementById("net-dhcp-toggle");
-        app.elements.netStaticFields= document.getElementById("net-static-fields");
-        app.elements.netIp          = document.getElementById("net-ip");
-        app.elements.netMask        = document.getElementById("net-mask");
-        app.elements.netGateway     = document.getElementById("net-gateway");
-        app.elements.netDns1        = document.getElementById("net-dns1");
-        app.elements.netSntp        = document.getElementById("net-sntp");
+        app.elements.netHostname    = g("net-hostname");
+        app.elements.netDhcp        = g("net-dhcp");
+        app.elements.netDhcpToggle  = g("net-dhcp-toggle");
+        app.elements.netStaticFields= g("net-static-fields");
+        app.elements.netIp          = g("net-ip");
+        app.elements.netMask        = g("net-mask");
+        app.elements.netGateway     = g("net-gateway");
+        app.elements.netDns1        = g("net-dns1");
+        app.elements.netSntp        = g("net-sntp");
 
         app.elements.netDhcpToggle.addEventListener("click", function () {
             app.elements.netDhcp.checked = !app.elements.netDhcp.checked;
@@ -252,7 +253,7 @@
             app.elements.netStaticFields.style.display = app.elements.netDhcp.checked ? "none" : "flex";
         });
 
-        document.getElementById("net-config-save").addEventListener("click", function () { saveNetworkConfig(app); });
+        g("net-config-save").addEventListener("click", function () { saveNetworkConfig(app); });
         loadNetworkConfig(app);
     }
 
@@ -295,10 +296,10 @@
     }
 
     function initIoConfig(app) {
-        app.elements.ioNodeIdInput          = document.getElementById("io-node-id");
-        app.elements.ioTxPowerInput         = document.getElementById("io-tx-power");
-        app.elements.ioPassiveModeCheckbox  = document.getElementById("io-passive-mode");
-        app.elements.ioPassiveToggle        = document.getElementById("io-passive-toggle");
+        app.elements.ioNodeIdInput          = g("io-node-id");
+        app.elements.ioTxPowerInput         = g("io-tx-power");
+        app.elements.ioPassiveModeCheckbox  = g("io-passive-mode");
+        app.elements.ioPassiveToggle        = g("io-passive-toggle");
 
         app.elements.ioPassiveToggle.addEventListener("click", function () {
             var chk = app.elements.ioPassiveModeCheckbox;
@@ -306,17 +307,17 @@
             app.elements.ioPassiveToggle.classList.toggle("on", chk.checked);
         });
 
-        document.getElementById("io-config-save").addEventListener("click", function () { saveIoConfig(app); });
+        g("io-config-save").addEventListener("click", function () { saveIoConfig(app); });
         loadIoConfig(app);
     }
 
     // ── Access Password ───────────────────────────────────────────────────────
 
     function initAccessPassword(app) {
-        app.elements.accessPasswordNew     = document.getElementById("access-password-new");
-        app.elements.accessPasswordConfirm = document.getElementById("access-password-confirm");
+        app.elements.accessPasswordNew     = g("access-password-new");
+        app.elements.accessPasswordConfirm = g("access-password-confirm");
 
-        document.getElementById("access-password-save").addEventListener("click", async function () {
+        g("access-password-save").addEventListener("click", async function () {
             const pwd     = app.elements.accessPasswordNew.value;
             const confirm = app.elements.accessPasswordConfirm.value;
 
@@ -350,9 +351,9 @@
     }
 
     function openIoKeyEditModal(app, prefill) {
-        const modal = document.getElementById("io-key-edit-modal");
-        const input = document.getElementById("io-key-new-input");
-        const status = document.getElementById("io-key-edit-status");
+        const modal = g("io-key-edit-modal");
+        const input = g("io-key-new-input");
+        const status = g("io-key-edit-status");
         input.value = prefill || "";
         status.textContent = "";
         modal.classList.add("open");
@@ -360,12 +361,12 @@
     }
 
     function closeIoKeyEditModal() {
-        document.getElementById("io-key-edit-modal").classList.remove("open");
+        g("io-key-edit-modal").classList.remove("open");
     }
 
     async function saveIoKey(app) {
-        const input = document.getElementById("io-key-new-input");
-        const status = document.getElementById("io-key-edit-status");
+        const input = g("io-key-new-input");
+        const status = g("io-key-edit-status");
         const key = input.value.trim().toUpperCase();
         if (!/^[0-9A-F]{32}$/.test(key)) {
             status.textContent = "Key must be exactly 32 hex characters (0-9, A-F).";
@@ -400,42 +401,42 @@
     }
 
     function openSniffModal() {
-        const modal = document.getElementById("io-key-sniff-modal");
-        document.getElementById("io-sniff-instructions").style.display = "";
-        document.getElementById("io-sniff-countdown-row").style.display = "none";
-        document.getElementById("io-sniff-result-row").style.display = "none";
-        document.getElementById("io-sniff-status").textContent = "";
-        document.getElementById("io-sniff-start").style.display = "";
-        document.getElementById("io-sniff-use-key").style.display = "none";
-        document.getElementById("io-sniff-retry").style.display = "none";
+        const modal = g("io-key-sniff-modal");
+        g("io-sniff-instructions").style.display = "";
+        g("io-sniff-countdown-row").style.display = "none";
+        g("io-sniff-result-row").style.display = "none";
+        g("io-sniff-status").textContent = "";
+        g("io-sniff-start").style.display = "";
+        g("io-sniff-use-key").style.display = "none";
+        g("io-sniff-retry").style.display = "none";
         modal.classList.add("open");
     }
 
     async function startSniff(app) {
-        document.getElementById("io-sniff-start").style.display = "none";
-        document.getElementById("io-sniff-retry").style.display = "none";
-        document.getElementById("io-sniff-result-row").style.display = "none";
-        document.getElementById("io-sniff-status").textContent = "";
-        document.getElementById("io-sniff-instructions").style.display = "none";
-        document.getElementById("io-sniff-countdown-row").style.display = "";
+        g("io-sniff-start").style.display = "none";
+        g("io-sniff-retry").style.display = "none";
+        g("io-sniff-result-row").style.display = "none";
+        g("io-sniff-status").textContent = "";
+        g("io-sniff-instructions").style.display = "none";
+        g("io-sniff-countdown-row").style.display = "";
 
         sniffSecondsLeft = 120;
-        document.getElementById("io-sniff-countdown").textContent = sniffSecondsLeft;
+        g("io-sniff-countdown").textContent = sniffSecondsLeft;
 
         try { await window.MiOpenApi.postJson("/api/io/sniff", { active: true }); } catch (e) {
-            document.getElementById("io-sniff-status").textContent = "Failed to start: " + (e.message || e);
-            document.getElementById("io-sniff-start").style.display = "";
+            g("io-sniff-status").textContent = "Failed to start: " + (e.message || e);
+            g("io-sniff-start").style.display = "";
             return;
         }
 
         sniffCountdownTimer = setInterval(function () {
             sniffSecondsLeft--;
-            document.getElementById("io-sniff-countdown").textContent = sniffSecondsLeft;
+            g("io-sniff-countdown").textContent = sniffSecondsLeft;
             if (sniffSecondsLeft <= 0) {
                 stopSniffPoll();
-                document.getElementById("io-sniff-countdown-row").style.display = "none";
-                document.getElementById("io-sniff-status").textContent = "No key captured. Try again.";
-                document.getElementById("io-sniff-retry").style.display = "";
+                g("io-sniff-countdown-row").style.display = "none";
+                g("io-sniff-status").textContent = "No key captured. Try again.";
+                g("io-sniff-retry").style.display = "";
             }
         }, 1000);
 
@@ -444,64 +445,64 @@
                 const r = await window.MiOpenApi.requestJson("/api/io/sniff");
                 if (r && r.key) {
                     stopSniffPoll();
-                    document.getElementById("io-sniff-countdown-row").style.display = "none";
-                    document.getElementById("io-sniff-captured-key").textContent = r.key;
-                    document.getElementById("io-sniff-result-row").style.display = "";
-                    document.getElementById("io-sniff-use-key").dataset.key = r.key;
-                    document.getElementById("io-sniff-use-key").style.display = "";
+                    g("io-sniff-countdown-row").style.display = "none";
+                    g("io-sniff-captured-key").textContent = r.key;
+                    g("io-sniff-result-row").style.display = "";
+                    g("io-sniff-use-key").dataset.key = r.key;
+                    g("io-sniff-use-key").style.display = "";
                 }
             } catch (e) { /* ignore poll errors */ }
         }, 2000);
     }
 
     function useSniffedKey(app) {
-        const key = document.getElementById("io-sniff-use-key").dataset.key;
-        document.getElementById("io-key-sniff-modal").classList.remove("open");
+        const key = g("io-sniff-use-key").dataset.key;
+        g("io-key-sniff-modal").classList.remove("open");
         stopSniffPoll();
         openIoKeyEditModal(app, key);
     }
 
     function initIoKey(app) {
-        app.elements.ioKeyDisplay = document.getElementById("io-key-display");
-        app.elements.ioKeyStatus  = document.getElementById("io-key-status");
+        app.elements.ioKeyDisplay = g("io-key-display");
+        app.elements.ioKeyStatus  = g("io-key-status");
 
-        document.getElementById("io-key-show").addEventListener("click", function () {
+        g("io-key-show").addEventListener("click", function () {
             const el = app.elements.ioKeyDisplay;
             el.type = el.type === "password" ? "text" : "password";
             this.textContent = el.type === "password" ? "Show" : "Hide";
         });
 
-        document.getElementById("io-key-edit").addEventListener("click", function () {
+        g("io-key-edit").addEventListener("click", function () {
             openIoKeyEditModal(app, app.elements.ioKeyDisplay.value);
         });
 
-        document.getElementById("io-key-sniff").addEventListener("click", function () {
+        g("io-key-sniff").addEventListener("click", function () {
             openSniffModal();
         });
 
-        document.getElementById("io-key-edit-cancel").addEventListener("click", closeIoKeyEditModal);
-        document.getElementById("io-key-edit-save").addEventListener("click", function () { saveIoKey(app); });
-        document.getElementById("io-key-generate").addEventListener("click", function () {
+        g("io-key-edit-cancel").addEventListener("click", closeIoKeyEditModal);
+        g("io-key-edit-save").addEventListener("click", function () { saveIoKey(app); });
+        g("io-key-generate").addEventListener("click", function () {
             const bytes = new Uint8Array(16);
             crypto.getRandomValues(bytes);
             const hex = Array.from(bytes).map(function (b) { return b.toString(16).padStart(2, "0").toUpperCase(); }).join("");
-            document.getElementById("io-key-new-input").value = hex;
-            document.getElementById("io-key-edit-status").textContent = "";
+            g("io-key-new-input").value = hex;
+            g("io-key-edit-status").textContent = "";
         });
-        document.getElementById("io-key-edit-modal").addEventListener("click", function (e) {
+        g("io-key-edit-modal").addEventListener("click", function (e) {
             if (e.target === this) closeIoKeyEditModal();
         });
 
-        document.getElementById("io-sniff-cancel").addEventListener("click", async function () {
+        g("io-sniff-cancel").addEventListener("click", async function () {
             await cancelSniff();
-            document.getElementById("io-key-sniff-modal").classList.remove("open");
+            g("io-key-sniff-modal").classList.remove("open");
         });
-        document.getElementById("io-key-sniff-modal").addEventListener("click", async function (e) {
+        g("io-key-sniff-modal").addEventListener("click", async function (e) {
             if (e.target === this) { await cancelSniff(); this.classList.remove("open"); }
         });
-        document.getElementById("io-sniff-start").addEventListener("click", function () { startSniff(app); });
-        document.getElementById("io-sniff-retry").addEventListener("click", function () { startSniff(app); });
-        document.getElementById("io-sniff-use-key").addEventListener("click", function () { useSniffedKey(app); });
+        g("io-sniff-start").addEventListener("click", function () { startSniff(app); });
+        g("io-sniff-retry").addEventListener("click", function () { startSniff(app); });
+        g("io-sniff-use-key").addEventListener("click", function () { useSniffedKey(app); });
 
         initLearnKey(app);
         initPairDeviceKey(app);
@@ -509,7 +510,7 @@
     }
 
     function initReboot() {
-        var btn = document.getElementById("reboot-btn");
+        var btn = g("reboot-btn");
         if (!btn) return;
         btn.addEventListener("click", function () {
             if (!confirm("Reboot the device now?")) return;
@@ -540,20 +541,20 @@
 
     function init(app) {
 
-        app.elements.fallbackEnabled        = document.getElementById("fallback-enabled");
-        app.elements.fallbackRetriesBoot    = document.getElementById("fallback-retries-boot");
-        app.elements.fallbackRetriesRunning = document.getElementById("fallback-retries-running");
-        app.elements.fallbackTimeout        = document.getElementById("fallback-timeout");
-        app.elements.fallbackStatus         = document.getElementById("fallback-status");
+        app.elements.fallbackEnabled        = g("fallback-enabled");
+        app.elements.fallbackRetriesBoot    = g("fallback-retries-boot");
+        app.elements.fallbackRetriesRunning = g("fallback-retries-running");
+        app.elements.fallbackTimeout        = g("fallback-timeout");
+        app.elements.fallbackStatus         = g("fallback-status");
         app.loadFallbackConfig = function () { return loadFallbackConfig(app); };
         app.saveFallbackConfig = function () { return saveFallbackConfig(app); };
-        document.getElementById("fallback-save").addEventListener("click", function () { app.saveFallbackConfig(); });
+        g("fallback-save").addEventListener("click", function () { app.saveFallbackConfig(); });
         loadFallbackConfig(app);
         fallbackStatusTimer = setInterval(function () { pollFallbackStatus(app); }, 15000);
         mqttStatusTimer = setInterval(function () { pollMqttStatus(app); }, 3000);
 
-        app.elements.mqttEnabledInput  = document.getElementById("mqtt-enabled");
-        app.elements.mqttEnabledToggle = document.getElementById("mqtt-enabled-toggle");
+        app.elements.mqttEnabledInput  = g("mqtt-enabled");
+        app.elements.mqttEnabledToggle = g("mqtt-enabled-toggle");
         var mqttSaveInFlight = false;
         app.elements.mqttEnabledToggle.addEventListener("click", function () {
             if (mqttSaveInFlight) return;
@@ -564,12 +565,12 @@
             updateMqttConfig(app, true).finally(function () { mqttSaveInFlight = false; });
         });
 
-        app.elements.wifiSsidInput     = document.getElementById("wifi-ssid");
-        app.elements.wifiPasswordInput = document.getElementById("wifi-password");
-        app.elements.wifiStatus        = document.getElementById("wifi-config-status");
+        app.elements.wifiSsidInput     = g("wifi-ssid");
+        app.elements.wifiPasswordInput = g("wifi-password");
+        app.elements.wifiStatus        = g("wifi-config-status");
         app.loadWifiConfig  = function () { return loadWifiConfig(app); };
         app.saveWifiConfig  = function () { return saveWifiConfig(app); };
-        document.getElementById("wifi-config-save").addEventListener("click", function () { app.saveWifiConfig(); });
+        g("wifi-config-save").addEventListener("click", function () { app.saveWifiConfig(); });
         loadWifiConfig(app);
 
         initNetworkConfig(app);
@@ -579,9 +580,9 @@
         initReboot();
 
         // Update channel toggle
-        var betaCheckbox = document.getElementById("update-channel-beta");
-        var betaLabel = document.getElementById("update-channel-label");
-        var betaToggle = document.getElementById("update-channel-toggle");
+        var betaCheckbox = g("update-channel-beta");
+        var betaLabel = g("update-channel-label");
+        var betaToggle = g("update-channel-toggle");
         if (betaCheckbox && betaToggle) {
             var savedChannel = localStorage.getItem("updateChannel") || "stable";
             betaCheckbox.checked = savedChannel === "beta";
@@ -599,8 +600,8 @@
 
         (function () {
 
-            var scanBtn     = document.getElementById("wifi-scan-btn");
-            var scanResults = document.getElementById("wifi-scan-results");
+            var scanBtn     = g("wifi-scan-btn");
+            var scanResults = g("wifi-scan-results");
             var ssidInput   = app.elements.wifiSsidInput;
             if (!scanBtn) return;
 
@@ -705,11 +706,11 @@
     function onKeyCaptured(key) {
         if (!key) return;
         stopSniffPoll();
-        document.getElementById("io-sniff-countdown-row").style.display = "none";
-        document.getElementById("io-sniff-captured-key").textContent = key;
-        document.getElementById("io-sniff-result-row").style.display = "";
-        document.getElementById("io-sniff-use-key").dataset.key = key;
-        document.getElementById("io-sniff-use-key").style.display = "";
+        g("io-sniff-countdown-row").style.display = "none";
+        g("io-sniff-captured-key").textContent = key;
+        g("io-sniff-result-row").style.display = "";
+        g("io-sniff-use-key").dataset.key = key;
+        g("io-sniff-use-key").style.display = "";
     }
 
     // ── IO Key Learn (receive key from TaHoma / Connectivity Kit) ────────────
@@ -719,12 +720,12 @@
 
     function resetLearnModal() {
         if (learnCountdownTimer) { clearInterval(learnCountdownTimer); learnCountdownTimer = null; }
-        document.getElementById("io-learn-countdown-row").style.display = "none";
-        document.getElementById("io-learn-result-row").style.display = "none";
-        document.getElementById("io-learn-status").textContent = "";
-        document.getElementById("io-learn-start").style.display = "";
-        document.getElementById("io-learn-retry").style.display = "none";
-        document.getElementById("io-learn-use-key").style.display = "none";
+        g("io-learn-countdown-row").style.display = "none";
+        g("io-learn-result-row").style.display = "none";
+        g("io-learn-status").textContent = "";
+        g("io-learn-start").style.display = "";
+        g("io-learn-retry").style.display = "none";
+        g("io-learn-use-key").style.display = "none";
     }
 
     async function cancelLearn() {
@@ -733,30 +734,30 @@
     }
 
     async function startLearn(app) {
-        document.getElementById("io-learn-start").style.display = "none";
-        document.getElementById("io-learn-retry").style.display = "none";
-        document.getElementById("io-learn-result-row").style.display = "none";
-        document.getElementById("io-learn-status").textContent = "";
-        document.getElementById("io-learn-countdown-row").style.display = "";
+        g("io-learn-start").style.display = "none";
+        g("io-learn-retry").style.display = "none";
+        g("io-learn-result-row").style.display = "none";
+        g("io-learn-status").textContent = "";
+        g("io-learn-countdown-row").style.display = "";
 
         learnSecondsLeft = 120;
-        document.getElementById("io-learn-countdown").textContent = learnSecondsLeft;
+        g("io-learn-countdown").textContent = learnSecondsLeft;
 
         try { await window.MiOpenApi.postJson("/api/learn/start", {}); } catch (e) {
-            document.getElementById("io-learn-status").textContent = "Failed to start: " + (e.message || e);
-            document.getElementById("io-learn-countdown-row").style.display = "none";
-            document.getElementById("io-learn-start").style.display = "";
+            g("io-learn-status").textContent = "Failed to start: " + (e.message || e);
+            g("io-learn-countdown-row").style.display = "none";
+            g("io-learn-start").style.display = "";
             return;
         }
 
         learnCountdownTimer = setInterval(function () {
             learnSecondsLeft--;
-            document.getElementById("io-learn-countdown").textContent = learnSecondsLeft;
+            g("io-learn-countdown").textContent = learnSecondsLeft;
             if (learnSecondsLeft <= 0) {
                 clearInterval(learnCountdownTimer); learnCountdownTimer = null;
-                document.getElementById("io-learn-countdown-row").style.display = "none";
-                document.getElementById("io-learn-status").textContent = "No key received. Try again.";
-                document.getElementById("io-learn-retry").style.display = "";
+                g("io-learn-countdown-row").style.display = "none";
+                g("io-learn-status").textContent = "No key received. Try again.";
+                g("io-learn-retry").style.display = "";
             }
         }, 1000);
     }
@@ -764,47 +765,47 @@
     function onLearnActive(remaining_s) {
         if (remaining_s !== undefined) {
             learnSecondsLeft = remaining_s;
-            document.getElementById("io-learn-countdown").textContent = learnSecondsLeft;
+            g("io-learn-countdown").textContent = learnSecondsLeft;
         }
     }
 
     function onLearnFailed() {
         if (learnCountdownTimer) { clearInterval(learnCountdownTimer); learnCountdownTimer = null; }
-        document.getElementById("io-learn-countdown-row").style.display = "none";
-        document.getElementById("io-learn-status").textContent = "Handshake failed — TaHoma did not complete the key exchange.";
-        document.getElementById("io-learn-retry").style.display = "";
+        g("io-learn-countdown-row").style.display = "none";
+        g("io-learn-status").textContent = "Handshake failed — TaHoma did not complete the key exchange.";
+        g("io-learn-retry").style.display = "";
     }
 
     function onLearnKey(key) {
         if (!key) return;
         if (learnCountdownTimer) { clearInterval(learnCountdownTimer); learnCountdownTimer = null; }
-        document.getElementById("io-learn-countdown-row").style.display = "none";
-        document.getElementById("io-learn-captured-key").textContent = key;
-        document.getElementById("io-learn-result-row").style.display = "";
-        document.getElementById("io-learn-use-key").dataset.key = key;
-        document.getElementById("io-learn-use-key").style.display = "";
-        document.getElementById("io-learn-status").textContent = "Key received!";
+        g("io-learn-countdown-row").style.display = "none";
+        g("io-learn-captured-key").textContent = key;
+        g("io-learn-result-row").style.display = "";
+        g("io-learn-use-key").dataset.key = key;
+        g("io-learn-use-key").style.display = "";
+        g("io-learn-status").textContent = "Key received!";
     }
 
     function initLearnKey(app) {
-        document.getElementById("io-key-learn").addEventListener("click", function () {
+        g("io-key-learn").addEventListener("click", function () {
             resetLearnModal();
-            document.getElementById("io-key-learn-modal").classList.add("open");
+            g("io-key-learn-modal").classList.add("open");
         });
 
-        document.getElementById("io-learn-cancel").addEventListener("click", async function () {
+        g("io-learn-cancel").addEventListener("click", async function () {
             await cancelLearn();
-            document.getElementById("io-key-learn-modal").classList.remove("open");
+            g("io-key-learn-modal").classList.remove("open");
         });
-        document.getElementById("io-key-learn-modal").addEventListener("click", async function (e) {
+        g("io-key-learn-modal").addEventListener("click", async function (e) {
             if (e.target === this) { await cancelLearn(); this.classList.remove("open"); }
         });
-        document.getElementById("io-learn-start").addEventListener("click", function () { startLearn(app); });
-        document.getElementById("io-learn-retry").addEventListener("click", function () { startLearn(app); });
-        document.getElementById("io-learn-use-key").addEventListener("click", async function () {
+        g("io-learn-start").addEventListener("click", function () { startLearn(app); });
+        g("io-learn-retry").addEventListener("click", function () { startLearn(app); });
+        g("io-learn-use-key").addEventListener("click", async function () {
             const key = this.dataset.key;
             await cancelLearn();
-            document.getElementById("io-key-learn-modal").classList.remove("open");
+            g("io-key-learn-modal").classList.remove("open");
             openIoKeyEditModal(app, key);
         });
     }
@@ -816,12 +817,12 @@
 
     function resetPairDeviceModal() {
         if (pairDeviceCountdownTimer) { clearInterval(pairDeviceCountdownTimer); pairDeviceCountdownTimer = null; }
-        document.getElementById("io-pair-device-countdown-row").style.display = "none";
-        document.getElementById("io-pair-device-result-row").style.display = "none";
-        document.getElementById("io-pair-device-status").textContent = "";
-        document.getElementById("io-pair-device-start").style.display = "";
-        document.getElementById("io-pair-device-retry").style.display = "none";
-        document.getElementById("io-pair-device-use-key").style.display = "none";
+        g("io-pair-device-countdown-row").style.display = "none";
+        g("io-pair-device-result-row").style.display = "none";
+        g("io-pair-device-status").textContent = "";
+        g("io-pair-device-start").style.display = "";
+        g("io-pair-device-retry").style.display = "none";
+        g("io-pair-device-use-key").style.display = "none";
     }
 
     async function cancelPairDevice() {
@@ -830,30 +831,30 @@
     }
 
     async function startPairDevice(app) {
-        document.getElementById("io-pair-device-start").style.display = "none";
-        document.getElementById("io-pair-device-retry").style.display = "none";
-        document.getElementById("io-pair-device-result-row").style.display = "none";
-        document.getElementById("io-pair-device-status").textContent = "";
-        document.getElementById("io-pair-device-countdown-row").style.display = "";
+        g("io-pair-device-start").style.display = "none";
+        g("io-pair-device-retry").style.display = "none";
+        g("io-pair-device-result-row").style.display = "none";
+        g("io-pair-device-status").textContent = "";
+        g("io-pair-device-countdown-row").style.display = "";
 
         pairDeviceSecondsLeft = 120;
-        document.getElementById("io-pair-device-countdown").textContent = pairDeviceSecondsLeft;
+        g("io-pair-device-countdown").textContent = pairDeviceSecondsLeft;
 
         try { await window.MiOpenApi.postJson("/api/pair-device/start", {}); } catch (e) {
-            document.getElementById("io-pair-device-status").textContent = "Failed to start: " + (e.message || e);
-            document.getElementById("io-pair-device-countdown-row").style.display = "none";
-            document.getElementById("io-pair-device-start").style.display = "";
+            g("io-pair-device-status").textContent = "Failed to start: " + (e.message || e);
+            g("io-pair-device-countdown-row").style.display = "none";
+            g("io-pair-device-start").style.display = "";
             return;
         }
 
         pairDeviceCountdownTimer = setInterval(function () {
             pairDeviceSecondsLeft--;
-            document.getElementById("io-pair-device-countdown").textContent = pairDeviceSecondsLeft;
+            g("io-pair-device-countdown").textContent = pairDeviceSecondsLeft;
             if (pairDeviceSecondsLeft <= 0) {
                 clearInterval(pairDeviceCountdownTimer); pairDeviceCountdownTimer = null;
-                document.getElementById("io-pair-device-countdown-row").style.display = "none";
-                document.getElementById("io-pair-device-status").textContent = "No key received. Try again.";
-                document.getElementById("io-pair-device-retry").style.display = "";
+                g("io-pair-device-countdown-row").style.display = "none";
+                g("io-pair-device-status").textContent = "No key received. Try again.";
+                g("io-pair-device-retry").style.display = "";
             }
         }, 1000);
     }
@@ -861,56 +862,122 @@
     function onPairDeviceActive(remaining_s) {
         if (remaining_s !== undefined) {
             pairDeviceSecondsLeft = remaining_s;
-            document.getElementById("io-pair-device-countdown").textContent = pairDeviceSecondsLeft;
+            g("io-pair-device-countdown").textContent = pairDeviceSecondsLeft;
         }
     }
 
     function onPairDeviceFailed() {
         if (pairDeviceCountdownTimer) { clearInterval(pairDeviceCountdownTimer); pairDeviceCountdownTimer = null; }
-        document.getElementById("io-pair-device-countdown-row").style.display = "none";
-        document.getElementById("io-pair-device-status").textContent = "Handshake failed — TaHoma did not complete the key exchange.";
-        document.getElementById("io-pair-device-retry").style.display = "";
+        g("io-pair-device-countdown-row").style.display = "none";
+        g("io-pair-device-status").textContent = "Handshake failed — TaHoma did not complete the key exchange.";
+        g("io-pair-device-retry").style.display = "";
     }
 
     function onPairDeviceKey(key) {
         if (!key) return;
         if (pairDeviceCountdownTimer) { clearInterval(pairDeviceCountdownTimer); pairDeviceCountdownTimer = null; }
-        document.getElementById("io-pair-device-countdown-row").style.display = "none";
-        document.getElementById("io-pair-device-captured-key").textContent = key;
-        document.getElementById("io-pair-device-result-row").style.display = "";
-        document.getElementById("io-pair-device-use-key").dataset.key = key;
-        document.getElementById("io-pair-device-use-key").style.display = "";
-        document.getElementById("io-pair-device-status").textContent = "Key received!";
+        g("io-pair-device-countdown-row").style.display = "none";
+        g("io-pair-device-captured-key").textContent = key;
+        g("io-pair-device-result-row").style.display = "";
+        g("io-pair-device-use-key").dataset.key = key;
+        g("io-pair-device-use-key").style.display = "";
+        g("io-pair-device-status").textContent = "Key received!";
     }
 
     function initPairDeviceKey(app) {
-        document.getElementById("io-key-pair-device").addEventListener("click", function () {
+        g("io-key-pair-device").addEventListener("click", function () {
             resetPairDeviceModal();
-            document.getElementById("io-key-pair-device-modal").classList.add("open");
+            g("io-key-pair-device-modal").classList.add("open");
         });
-        document.getElementById("io-pair-device-cancel").addEventListener("click", async function () {
+        g("io-pair-device-cancel").addEventListener("click", async function () {
             await cancelPairDevice();
-            document.getElementById("io-key-pair-device-modal").classList.remove("open");
+            g("io-key-pair-device-modal").classList.remove("open");
         });
-        document.getElementById("io-key-pair-device-modal").addEventListener("click", async function (e) {
+        g("io-key-pair-device-modal").addEventListener("click", async function (e) {
             if (e.target === this) { await cancelPairDevice(); this.classList.remove("open"); }
         });
-        document.getElementById("io-pair-device-start").addEventListener("click", function () { startPairDevice(app); });
-        document.getElementById("io-pair-device-retry").addEventListener("click", function () { startPairDevice(app); });
-        document.getElementById("io-pair-device-use-key").addEventListener("click", async function () {
+        g("io-pair-device-start").addEventListener("click", function () { startPairDevice(app); });
+        g("io-pair-device-retry").addEventListener("click", function () { startPairDevice(app); });
+        g("io-pair-device-use-key").addEventListener("click", async function () {
             const key = this.dataset.key;
             await cancelPairDevice();
-            document.getElementById("io-key-pair-device-modal").classList.remove("open");
+            g("io-key-pair-device-modal").classList.remove("open");
             openIoKeyEditModal(app, key);
         });
+    }
+
+    // ── Send Key observation ──────────────────────────────────────────────────
+
+    let sendKeyTimer = null;
+    let sendKeySeconds = 0;
+
+    function resetSendKeyModal() {
+        if (sendKeyTimer) { clearInterval(sendKeyTimer); sendKeyTimer = null; }
+        g("io-send-key-countdown-row").style.display = "none";
+        g("io-send-key-status").textContent = "";
+        g("io-send-key-start").style.display = "";
+    }
+
+    async function startSendKey() {
+        if (sendKeyTimer) { clearInterval(sendKeyTimer); sendKeyTimer = null; }
+        g("io-send-key-start").style.display = "none";
+        g("io-send-key-status").textContent = "";
+        g("io-send-key-countdown-row").style.display = "";
+        sendKeySeconds = 30;
+        g("io-send-key-countdown").textContent = sendKeySeconds;
+        try { await window.MiOpenApi.postJson("/api/send-key/start", {}); } catch (e) {
+            g("io-send-key-status").textContent = "Failed to start: " + (e.message || e);
+            g("io-send-key-countdown-row").style.display = "none";
+            g("io-send-key-start").style.display = "";
+            return;
+        }
+        sendKeyTimer = setInterval(function () {
+            sendKeySeconds--;
+            g("io-send-key-countdown").textContent = sendKeySeconds;
+            if (sendKeySeconds <= 0) {
+                clearInterval(sendKeyTimer); sendKeyTimer = null;
+                g("io-send-key-countdown-row").style.display = "none";
+                g("io-send-key-status").textContent = "Session ended. Check Graylog for observed frames.";
+                g("io-send-key-start").style.display = "";
+            }
+        }, 1000);
+    }
+
+    function onSendKeyDone() {
+        if (sendKeyTimer) { clearInterval(sendKeyTimer); sendKeyTimer = null; }
+        g("io-send-key-countdown-row").style.display = "none";
+        g("io-send-key-status").textContent = "Session ended. Check Graylog for observed frames.";
+        g("io-send-key-start").style.display = "";
+    }
+
+    function initSendKey() {
+        g("io-key-send-key").addEventListener("click", function () {
+            resetSendKeyModal();
+            g("io-send-key-modal").classList.add("open");
+        });
+        g("io-send-key-cancel").addEventListener("click", async function () {
+            if (sendKeyTimer) { clearInterval(sendKeyTimer); sendKeyTimer = null; }
+            try { await window.MiOpenApi.postJson("/api/send-key/stop", {}); } catch (e) { /* ignore */ }
+            g("io-send-key-modal").classList.remove("open");
+        });
+        g("io-send-key-modal").addEventListener("click", async function (e) {
+            if (e.target !== this) return;
+            if (sendKeyTimer) { clearInterval(sendKeyTimer); sendKeyTimer = null; }
+            try { await window.MiOpenApi.postJson("/api/send-key/stop", {}); } catch (e) { /* ignore */ }
+            this.classList.remove("open");
+        });
+        g("io-send-key-start").addEventListener("click", function () { startSendKey(); });
     }
 
     window.MiOpenSettings = {
         init: init,
         onKeyCaptured: onKeyCaptured,
         onLearnActive: onLearnActive, onLearnFailed: onLearnFailed, onLearnKey: onLearnKey,
-        onPairDeviceActive: onPairDeviceActive, onPairDeviceFailed: onPairDeviceFailed, onPairDeviceKey: onPairDeviceKey
+        onPairDeviceActive: onPairDeviceActive, onPairDeviceFailed: onPairDeviceFailed, onPairDeviceKey: onPairDeviceKey,
+        onSendKeyDone: onSendKeyDone
     };
+
+    init_hooks.push(function (app) { initSendKey(); });
 })();
 
 // ── Syslog (settings section) ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

  ### Key pull (LearnKeyFromController)
  - Fix 2W IV construction: `crypt_2w_key` frame_data must be `[cmd_byte, challenge[0..5]]` (7 bytes) — fixes CMD 32 decryption across all paths (sniffer, LearnKeyFromController,
  PairAsDevice)
  - Simplified sequence: CMD 38 sent directly after CMD 29, up to 3 retries per cycle (100ms / 100ms / 1000ms windows) with the same challenge — CMD 32 now arrives reliably within 2
  attempts
  - Tested and removed: CMD 2C/2D confirmation handshake breaks TaHoma's key exchange; CMD 3C and CMD 33 receive no response from TaHoma

  ### WaitAndRespondToCmd28
  - Mutex must be held before reading sRxIoQueue (race condition fix)
  - Sends CMD 31→38 after CMD 29 for full key exchange sequence
  - CMD 29 data format corrections: byte[6] `0xDC→0xCC`, last byte counter→`0x00` to match TaHoma gateway format
  - Extended observation window to 20s, added CMD 29 data logging

  ### Other
  - Add Send Key step-by-step observation feature (UI + backend routes)
  - Raise `max_uri_handlers` from 48 to 52 (send-key routes exceeded limit)

  ## Test plan
  - [ ] Trigger TaHoma key-send mode — confirm CMD 32 received and decrypted to correct system key
  - [ ] Verify no regression in normal device control
